### PR TITLE
Enforce Rails 5.2 defaults

### DIFF
--- a/app/models/constituency_petition_journal.rb
+++ b/app/models/constituency_petition_journal.rb
@@ -1,6 +1,6 @@
 class ConstituencyPetitionJournal < ActiveRecord::Base
   belongs_to :petition
-  belongs_to :constituency
+  belongs_to :constituency, optional: true
 
   validates :petition, presence: true
   validates :constituency_id, presence: true, length: { maximum: 255 }

--- a/app/models/domain.rb
+++ b/app/models/domain.rb
@@ -2,7 +2,7 @@ class Domain < ActiveRecord::Base
   PATTERN = /\A(?:\*|\*\.[a-z]{2,}|(?:\*\.)*(?:[a-z0-9][a-z0-9-]{0,61}[a-z0-9]\.)+[a-z]{2,})\z/
 
   with_options class_name: "::Domain" do
-    belongs_to :canonical_domain, required: false
+    belongs_to :canonical_domain, optional: true
     has_many :aliases, foreign_key: "canonical_domain_id", dependent: :destroy
   end
 

--- a/app/models/invalidation.rb
+++ b/app/models/invalidation.rb
@@ -4,7 +4,7 @@ class Invalidation < ActiveRecord::Base
   extend Searchable(:id, :summary, :details, :petition_id)
   include Browseable
 
-  belongs_to :petition
+  belongs_to :petition, optional: true
   has_many :signatures
 
   facet :all,       -> { by_most_recent }

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -70,10 +70,10 @@ class Petition < ActiveRecord::Base
 
   filter :topic, ->(codes) { topics(codes) }
 
-  has_one :creator, -> { creator }, class_name: 'Signature'
+  has_one :creator, -> { creator }, class_name: 'Signature', inverse_of: :petition
   accepts_nested_attributes_for :creator, update_only: true
 
-  belongs_to :locked_by, class_name: 'AdminUser'
+  belongs_to :locked_by, class_name: 'AdminUser', optional: true
 
   has_one :debate_outcome, dependent: :destroy
   has_one :email_requested_receipt, dependent: :destroy

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -34,7 +34,7 @@ class Signature < ActiveRecord::Base
   }
 
   belongs_to :petition
-  belongs_to :invalidation
+  belongs_to :invalidation, optional: true
   has_one :contact # on_delete: :cascade
 
   validates :state, inclusion: { in: STATES }

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,6 +20,9 @@ Bundler.require(*Rails.groups)
 
 module WelshPets
   class Application < Rails::Application
+    # Initialize configuration defaults for originally generated Rails version.
+    config.load_defaults 5.2
+
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -23,6 +23,7 @@ FactoryBot.define do
   factory :petition do
     transient do
       admin_notes { nil }
+      creator { nil }
       creator_name { nil }
       creator_email { nil }
       creator_attributes { {} }
@@ -42,7 +43,7 @@ FactoryBot.define do
     end
 
     after(:build) do |petition, evaluator|
-      petition.creator ||= FactoryBot.build(:validated_signature, creator: true)
+      petition.creator ||= evaluator.creator || build(:validated_signature, petition: petition, creator: true)
       petition.creator.assign_attributes(evaluator.creator_attributes)
 
       if evaluator.creator_name
@@ -383,6 +384,7 @@ FactoryBot.define do
     state                 Signature::VALIDATED_STATE
 
     after(:build) do |signature, evaluator|
+      signature.petition ||= build(:petition, creator: (signature.creator ? signature : nil))
       build(:contact, signature: signature) if signature.creator?
     end
 

--- a/spec/models/invalidation_spec.rb
+++ b/spec/models/invalidation_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Invalidation, type: :model do
   end
 
   describe "associations" do
-    it { is_expected.to belong_to(:petition) }
+    it { is_expected.to belong_to(:petition).optional }
     it { is_expected.to have_many(:signatures) }
   end
 

--- a/spec/models/member_spec.rb
+++ b/spec/models/member_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe Member, type: :model do
   end
 
   describe "associations" do
-    it { is_expected.to belong_to(:region) }
-    it { is_expected.to belong_to(:constituency) }
+    it { is_expected.to belong_to(:region).optional }
+    it { is_expected.to belong_to(:constituency).optional }
   end
 
   describe "indexes" do

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -79,7 +79,7 @@ RSpec.describe Signature, type: :model do
 
   describe "associations" do
     it { is_expected.to belong_to(:petition) }
-    it { is_expected.to belong_to(:invalidation) }
+    it { is_expected.to belong_to(:invalidation).optional }
     it { is_expected.to have_one(:contact) }
   end
 
@@ -1001,10 +1001,12 @@ RSpec.describe Signature, type: :model do
   end
 
   describe ".trending_domains" do
+    let!(:petition) { FactoryBot.create(:open_petition, open_at: 2.weeks.ago, creator_attributes: { validated_at: 2.weeks.ago } ) }
+
     before do
-      FactoryBot.create(:validated_signature, email: "alice@foo.com", validated_at: 30.minutes.ago)
-      FactoryBot.create(:validated_signature, email: "bob@bar.com", validated_at: 30.minutes.ago)
-      FactoryBot.create(:validated_signature, email: "charlie@foo.com", validated_at: 30.minutes.ago)
+      FactoryBot.create(:validated_signature, petition: petition, email: "alice@foo.com", validated_at: 30.minutes.ago)
+      FactoryBot.create(:validated_signature, petition: petition, email: "bob@bar.com", validated_at: 30.minutes.ago)
+      FactoryBot.create(:validated_signature, petition: petition, email: "charlie@foo.com", validated_at: 30.minutes.ago)
     end
 
     it "returns a hash of domains and counts in descending order" do
@@ -1015,28 +1017,28 @@ RSpec.describe Signature, type: :model do
     end
 
     it "ignores pending signatures" do
-      FactoryBot.create(:pending_signature, email: "derek@foo.com", created_at: 30.minutes.ago)
+      FactoryBot.create(:pending_signature, petition: petition, email: "derek@foo.com", created_at: 30.minutes.ago)
       domains = described_class.trending_domains
 
       expect(domains.to_a).to eq([["foo.com", 2], ["bar.com", 1]])
     end
 
     it "ignores invalidated signatures" do
-      FactoryBot.create(:invalidated_signature, email: "derek@foo.com", validated_at: 30.minutes.ago, invalidated_at: 10.minutes.ago)
+      FactoryBot.create(:invalidated_signature, petition: petition, email: "derek@foo.com", validated_at: 30.minutes.ago, invalidated_at: 10.minutes.ago)
       domains = described_class.trending_domains
 
       expect(domains.to_a).to eq([["foo.com", 2], ["bar.com", 1]])
     end
 
     it "ignores fraudulent signatures" do
-      FactoryBot.create(:fraudulent_signature, email: "derek@foo.com", created_at: 30.minutes.ago)
+      FactoryBot.create(:fraudulent_signature, petition: petition, email: "derek@foo.com", created_at: 30.minutes.ago)
       domains = described_class.trending_domains
 
       expect(domains.to_a).to eq([["foo.com", 2], ["bar.com", 1]])
     end
 
     it "can override the timespan" do
-      FactoryBot.create(:validated_signature, email: "derek@foo.com", validated_at: 5.minutes.ago)
+      FactoryBot.create(:validated_signature, petition: petition, email: "derek@foo.com", validated_at: 5.minutes.ago)
       domains = described_class.trending_domains(since: 10.minutes.ago)
 
       expect(domains.to_a).to eq([["foo.com", 1]])
@@ -1050,51 +1052,53 @@ RSpec.describe Signature, type: :model do
   end
 
   describe ".trending_ips" do
+    let!(:petition) { FactoryBot.create(:open_petition, open_at: 2.weeks.ago, creator_attributes: { validated_at: 2.weeks.ago } ) }
+
     before do
-      FactoryBot.create(:validated_signature, ip_address: "10.0.1.1", validated_at: 30.minutes.ago)
-      FactoryBot.create(:validated_signature, ip_address: "192.168.1.1", validated_at: 30.minutes.ago)
-      FactoryBot.create(:validated_signature, ip_address: "10.0.1.1", validated_at: 30.minutes.ago)
+      FactoryBot.create(:validated_signature, petition: petition, ip_address: "10.0.1.1", validated_at: 30.minutes.ago)
+      FactoryBot.create(:validated_signature, petition: petition, ip_address: "192.168.1.1", validated_at: 30.minutes.ago)
+      FactoryBot.create(:validated_signature, petition: petition, ip_address: "10.0.1.1", validated_at: 30.minutes.ago)
     end
 
-    it "returns a hash of domains and counts in descending order" do
-      domains = described_class.trending_ips
+    it "returns a hash of ip addresses and counts in descending order" do
+      ip_addresses = described_class.trending_ips
 
-      expect(domains).to be_an_instance_of(Hash)
-      expect(domains.to_a).to eq([["10.0.1.1", 2], ["192.168.1.1", 1]])
+      expect(ip_addresses).to be_an_instance_of(Hash)
+      expect(ip_addresses.to_a).to eq([["10.0.1.1", 2], ["192.168.1.1", 1]])
     end
 
     it "ignores pending signatures" do
-      FactoryBot.create(:pending_signature, ip_address: "10.0.1.1", created_at: 30.minutes.ago)
-      domains = described_class.trending_ips
+      FactoryBot.create(:pending_signature, petition: petition, ip_address: "10.0.1.1", created_at: 30.minutes.ago)
+      ip_addresses = described_class.trending_ips
 
-      expect(domains.to_a).to eq([["10.0.1.1", 2], ["192.168.1.1", 1]])
+      expect(ip_addresses.to_a).to eq([["10.0.1.1", 2], ["192.168.1.1", 1]])
     end
 
     it "ignores invalidated signatures" do
-      FactoryBot.create(:invalidated_signature, ip_address: "10.0.1.1", validated_at: 30.minutes.ago, invalidated_at: 10.minutes.ago)
-      domains = described_class.trending_ips
+      FactoryBot.create(:invalidated_signature, petition: petition, ip_address: "10.0.1.1", validated_at: 30.minutes.ago, invalidated_at: 10.minutes.ago)
+      ip_addresses = described_class.trending_ips
 
-      expect(domains.to_a).to eq([["10.0.1.1", 2], ["192.168.1.1", 1]])
+      expect(ip_addresses.to_a).to eq([["10.0.1.1", 2], ["192.168.1.1", 1]])
     end
 
     it "ignores fraudulent signatures" do
-      FactoryBot.create(:fraudulent_signature, ip_address: "10.0.1.1", created_at: 30.minutes.ago)
-      domains = described_class.trending_ips
+      FactoryBot.create(:fraudulent_signature, petition: petition, ip_address: "10.0.1.1", created_at: 30.minutes.ago)
+      ip_addresses = described_class.trending_ips
 
-      expect(domains.to_a).to eq([["10.0.1.1", 2], ["192.168.1.1", 1]])
+      expect(ip_addresses.to_a).to eq([["10.0.1.1", 2], ["192.168.1.1", 1]])
     end
 
     it "can override the timespan" do
-      FactoryBot.create(:validated_signature, ip_address: "10.0.1.1", validated_at: 5.minutes.ago)
-      domains = described_class.trending_ips(since: 10.minutes.ago)
+      FactoryBot.create(:validated_signature, petition: petition, ip_address: "10.0.1.1", validated_at: 5.minutes.ago)
+      ip_addresses = described_class.trending_ips(since: 10.minutes.ago)
 
-      expect(domains.to_a).to eq([["10.0.1.1", 1]])
+      expect(ip_addresses.to_a).to eq([["10.0.1.1", 1]])
     end
 
     it "can override the number returned" do
-      domains = described_class.trending_ips(limit: 1)
+      ip_addresses = described_class.trending_ips(limit: 1)
 
-      expect(domains.to_a).to eq([["10.0.1.1", 2]])
+      expect(ip_addresses.to_a).to eq([["10.0.1.1", 2]])
     end
   end
 
@@ -2018,8 +2022,9 @@ RSpec.describe Signature, type: :model do
     end
 
     describe "#need_emailing_for" do
-      let!(:a_signature) { FactoryBot.create(:validated_signature) }
-      let!(:another_signature) { FactoryBot.create(:validated_signature) }
+      let!(:petition) { FactoryBot.create(:open_petition, open_at: 2.weeks.ago, creator_attributes: { validated_at: 2.weeks.ago, petition_email_at: 1.day.ago }) }
+      let!(:a_signature) { FactoryBot.create(:validated_signature, petition: petition) }
+      let!(:another_signature) { FactoryBot.create(:validated_signature, petition: petition) }
       let(:since_timestamp) { 5.days.ago }
 
       subject { Signature.need_emailing_for('petition_email', since: since_timestamp) }
@@ -2050,7 +2055,6 @@ RSpec.describe Signature, type: :model do
       end
 
       it "returns signatures that have null for the requested timestamp" do
-        a_signature.update_column(:petition_email_at, nil)
         expect(subject).to match_array [a_signature, another_signature]
       end
     end


### PR DESCRIPTION
In Rails 5.2, the belongs_to association is required by default so we need to mark some as optional. We also need to tweak the factories and some test setup to ensure we meet the new requirements.