### PR TITLE
fix: remove historical migrations

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -12,3 +12,11 @@ task default: %i[
   bundle:audit brakeman:check
   spec jasmine:ci cucumber
 ]
+
+task :load_schema_if_empty do
+  unless Site.table_exists?
+    Rake::Task["db:schema:load"].invoke
+  end
+end
+
+Rake::Task["db:migrate"].enhance(%w[load_schema_if_empty])

--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -295,7 +295,7 @@ class PackageBuilder
   end
 
   def region
-    ENV.fetch('AWS_REGION', 'eu-west-1')
+    ENV.fetch('AWS_REGION', 'eu-west-2')
   end
 
   def release_bucket


### PR DESCRIPTION
Start from a clean slate by surcharging `db:migrate` to load the
database schema if it doesn't exist.

Co-authored-by: Andrew White <andrew.white@unboxedconsulting.com>