### PR TITLE
Lock puma to < 5 whilst we rework init.d script

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -70,5 +70,5 @@ group :test do
 end
 
 group :production do
-  gem 'puma'
+  gem 'puma', '< 5'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -269,7 +269,7 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
     public_suffix (4.0.3)
-    puma (5.1.1)
+    puma (4.3.7)
       nio4r (~> 2.0)
     racc (1.5.2)
     rack (2.2.3)
@@ -442,7 +442,7 @@ DEPENDENCIES
   paperclip
   pg
   pry
-  puma
+  puma (< 5)
   rails (= 6.1.1)
   rails-controller-testing
   rake


### PR DESCRIPTION
The daemonization code was removed in puma/puma#2170 which is the right thing to do but we'll need to switch to a systemd script so lock to a previous version while we get that sorted.