### PR TITLE
Allow sponsor count to be zero

### DIFF
--- a/app/controllers/petitioners_controller.rb
+++ b/app/controllers/petitioners_controller.rb
@@ -1,0 +1,22 @@
+class PetitionersController < SponsorsController
+  before_action :block_if_collecting_sponsors
+
+  def verify
+    @petition.validate_creator!
+
+    redirect_to moderation_info_petition_url(@petition)
+  end
+
+  private
+
+  def block_if_collecting_sponsors
+    if Site.collecting_sponsors?
+      raise ActionController::RoutingError, "Not available when collecting sponsors"
+    end
+  end
+
+  def retrieve_signature
+    @signature = Signature.find(signature_id)
+    @petition = @signature.petition
+  end
+end

--- a/app/jobs/email_confirmation_for_creator_email_job.rb
+++ b/app/jobs/email_confirmation_for_creator_email_job.rb
@@ -1,0 +1,15 @@
+class EmailConfirmationForCreatorEmailJob < NotifyJob
+  self.template = :email_confirmation_for_creator
+
+  include RateLimiting
+
+  def personalisation(signature, petition)
+    {
+      action_en:  petition.action_en, action_gd: petition.action_gd,
+      url_en:  verify_petitioner_en_url(signature, token: signature.perishable_token),
+      url_gd:  verify_petitioner_gd_url(signature, token: signature.perishable_token),
+      moderation_info_url_en: help_en_url(anchor: 'standards'),
+      moderation_info_url_gd: help_gd_url(anchor: 'standards'),
+    }
+  end
+end

--- a/app/models/petition_creator.rb
+++ b/app/models/petition_creator.rb
@@ -139,7 +139,12 @@ class PetitionCreator
 
       unless rate_limit.exceeded?(@petition.creator)
         @petition.save!
-        send_email_to_gather_sponsors(@petition)
+
+        if Site.collecting_sponsors?
+          send_email_to_gather_sponsors(@petition)
+        else
+          send_email_to_validate_creator(@petition)
+        end
       end
 
       return true
@@ -361,6 +366,10 @@ class PetitionCreator
 
   def send_email_to_gather_sponsors(petition)
     GatherSponsorsForPetitionEmailJob.perform_later(petition.creator)
+  end
+
+  def send_email_to_validate_creator(petition)
+    EmailConfirmationForCreatorEmailJob.perform_later(petition.creator)
   end
 
   private

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -242,6 +242,10 @@ class Site < ActiveRecord::Base
       bypass_token.present?
     end
 
+    def collecting_sponsors?
+      minimum_number_of_sponsors > 0
+    end
+
     private
 
     def default_title_en

--- a/app/views/petitions/moderation_info.html.erb
+++ b/app/views/petitions/moderation_info.html.erb
@@ -1,6 +1,8 @@
 <h1><%= t(:"ui.petitions.moderation_info.heading") %></h1>
 
-<p><%= t(:"ui.petitions.moderation_info.min_supporters_reached", min_supporters: Site.minimum_number_of_sponsors, creator_name: @petition.creator.name) %></p>
+<% if Site.collecting_sponsors? %>
+  <p><%= t(:"ui.petitions.moderation_info.min_supporters_reached", min_supporters: Site.minimum_number_of_sponsors, creator_name: @petition.creator.name) %></p>
+<% end %>
 
 <p><%= t(:"ui.petitions.moderation_info.checking_standards_html", standards_link: petition_standards_link) %></p>
 

--- a/config/locales/notify.en-GB.yml
+++ b/config/locales/notify.en-GB.yml
@@ -2,6 +2,7 @@ en-GB:
   notify:
     templates:
       email_confirmation_for_signer: "d1f5e610-5455-41ec-b71d-776c61ad9cac"
+      email_confirmation_for_creator: "2b9f7f53-1f28-446d-9502-cb77d0928f61"
       email_creator_about_other_business: "1b64c2cc-d9f0-49ef-920e-34716aff1fc2"
       email_duplicate_signatures: "ba9c3050-cc8b-410b-b3d2-30c692ffb91c"
       email_duplicate_sponsor: "3a7e8201-52c5-4dc9-a349-7e2235312147"

--- a/config/locales/notify.gd-GB.yml
+++ b/config/locales/notify.gd-GB.yml
@@ -2,6 +2,7 @@ gd-GB:
   notify:
     templates:
       email_confirmation_for_signer: "b79b908a-5b2f-4577-a03e-d8c625a2e280"
+      email_confirmation_for_creator: "cbf205c3-9d3a-4d97-8dd6-c367ecaeb8cd"
       email_creator_about_other_business: "e62c1f63-ea30-4d91-86a2-4e290c13fb0c"
       email_duplicate_signatures: "a3997c4b-8f4e-4013-abcb-fdbbbb6f5950"
       email_duplicate_sponsor: "5cca1ad8-1214-41b0-8abe-bf982463dc01"
@@ -29,7 +30,7 @@ gd-GB:
       sponsor_signed_email_on_threshold_christmas: "a41374bb-235b-4203-8ed2-076961c7554c"
       sponsor_signed_email_on_threshold_easter: "8c18ec4e-c6a5-4939-bbdd-19fbb1e392d3"
       sponsor_signed_email_on_threshold: "20cb31ed-5758-4fd4-9d0d-69fe6c1f4818"
-      
+
     strings:
       sponsor_count:
         zero: "You have 0 supporters so far"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -71,6 +71,10 @@ Rails.application.routes.draw do
       get '/:id', action: 'show',  as: :petition
     end
 
+    scope '/petitioners', controller: 'petitioners' do
+      get '/:id/verify', action: 'verify', as: :verify_petitioner
+    end
+
     scope '/sponsors', controller: 'sponsors' do
       get '/:id/verify',    action: 'verify', as: :verify_sponsor
       get '/:id/sponsored', action: 'signed', as: :signed_sponsor

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -57,6 +57,26 @@ Scenario: Charlie creates a petition with a custom closing date
   When I press "Yes – this is my email address"
   Then the petition "The wombats of wimbledon rock." should exist with a closing date of "2020-08-31"
 
+Scenario: Charlie creates a petition when sponsor count is set to 0
+  Given the site is not collecting sponsors
+  And I start a new petition
+  And I fill in the petition details
+  And I press "Preview petition"
+  And I press "This looks good"
+  And I choose the default closing date
+  And I fill in my details as a creator
+  And I fill in my creator contact details
+  When I press "Continue"
+  Then the markup should be valid
+  And I am asked to review my email address
+  When I press "Yes – this is my email address"
+  Then a petition should exist with action_en: "The wombats of wimbledon rock.", action_gd: nil, state: "pending", locale: "en-GB"
+  And there should be a "pending" signature with email "womboid@wimbledon.com" and name "Womboid Wibbledon"
+  And "Womboid Wibbledon" wants to be notified about the petition's progress
+  And "womboid@wimbledon.com" should be emailed a link for validating their signature
+  When I confirm my email
+  Then a petition should exist with action_en: "The wombats of wimbledon rock.", state: "sponsored"
+
 @gaelic
 Scenario: Charlie creates a petition in Gaelic
   Given I start a new petition

--- a/features/step_definitions/extra_steps.rb
+++ b/features/step_definitions/extra_steps.rb
@@ -190,3 +190,25 @@ end
 Given(/^a petition "([^"]*)" exists$/) do |action|
   @petition = FactoryBot.create(:petition, action: action)
 end
+
+Then(/^"([^"]*)" should be emailed a link for validating their signature$/) do |address|
+  open_last_email_for(address)
+  steps %{
+    Then they should see "Please confirm your email" in the email subject
+    When they open the email with subject "Please confirm your email"
+  }
+  steps %{
+    Then they should see /Click this link to confirm your email/ in the email body
+  }
+end
+
+When(/^I confirm my email$/) do
+  steps %Q(
+    When I click the first link in the email
+  )
+end
+
+Then(/^a petition should exist with action_en: "([^"]*)", state: "([^"]*)"$/) do |action_en, state|
+  petition = Petition.where(action_en: action_en, state: state)
+  expect(petition).to exist
+end

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -334,6 +334,13 @@ When(/^I click to see more details$/) do
   click_details "More details"
 end
 
+Given(/^the site is not collecting sponsors$/) do
+  Site.instance.update!(
+    minimum_number_of_sponsors: 0,
+    threshold_for_moderation: 0
+  )
+end
+
 Given(/^an? (open|closed|rejected) petition "(.*?)" with some (fraudulent)? ?signatures$/) do |state, petition_action, signature_state|
   petition_closed_at = state == 'closed' ? 1.day.ago : nil
   petition_state = state == 'closed' ? 'open' : state

--- a/spec/controllers/petitioners_controller_spec.rb
+++ b/spec/controllers/petitioners_controller_spec.rb
@@ -1,0 +1,89 @@
+require 'rails_helper'
+
+RSpec.describe PetitionersController, type: :controller do
+  before do
+    constituency = FactoryBot.create(:constituency, :glasgow_provan)
+    allow(Constituency).to receive(:find_by_postcode).with("G340BX").and_return(constituency)
+
+    Site.instance.update!(
+      minimum_number_of_sponsors: 0,
+      threshold_for_moderation: 0
+    )
+  end
+
+  describe "GET /petitioners/:id/verify" do
+    context "when the signature doesn't exist" do
+      it "raises an ActiveRecord::RecordNotFound exception" do
+        expect {
+          get :verify, params: { id: 1, token: "token" }
+        }.to raise_exception(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when the signature token is invalid" do
+      let(:petition) { FactoryBot.create(:open_petition) }
+      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+      it "raises an ActiveRecord::RecordNotFound exception" do
+        expect {
+          get :verify, params: { id: signature.id, token: "token" }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+
+    context "when the petition is pending" do
+      let(:petition) { FactoryBot.create(:pending_petition) }
+      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+      let(:creator) { petition.creator }
+
+      before do
+        get :verify, params: { id: signature.id, token: signature.perishable_token }
+      end
+
+      it "validates the creator's signature" do
+        expect(creator.reload.validated?).to eq(true)
+      end
+
+      it "changes the petition state to sponsored" do
+        expect(petition.reload.state).to eq("sponsored")
+      end
+
+      it "redirects to the moderation info page" do
+        expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+      end
+    end
+
+    %w[validated sponsored].each do |state|
+      context "when the petition is #{state}" do
+        let(:petition) { FactoryBot.create(:"#{state}_petition") }
+        let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+        before do
+          get :verify, params: { id: signature.id, token: signature.perishable_token }
+        end
+
+        it "redirects to the moderation info page" do
+          expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+        end
+      end
+    end
+
+    context "when the site is collecting sponsors" do
+      let(:petition) { FactoryBot.create(:pending_petition) }
+      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+      before do
+        Site.instance.update!(
+          minimum_number_of_sponsors: 2,
+          threshold_for_moderation: 2
+        )
+      end
+
+      it "returns a 404 error" do
+        expect {
+          get :verify, params: { id: signature.id, token: signature.perishable_token }
+        }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end

--- a/spec/fixtures/notify/2b9f7f53-1f28-446d-9502-cb77d0928f61.yml
+++ b/spec/fixtures/notify/2b9f7f53-1f28-446d-9502-cb77d0928f61.yml
@@ -1,0 +1,19 @@
+id: "2b9f7f53-1f28-446d-9502-cb77d0928f61"
+name: "email_confirmation_for_creator_en"
+subject: "Please confirm your email"
+body: |-
+  Click this link to confirm your email:
+
+  # ((action_en))
+
+  ((url_en))
+
+  After you have confirmed your email, we will check your petition to make sure it meets the petition criteria.
+  If it does, we’ll publish it and let you know. This usually takes a week or less.
+
+  Find out how we check petitions before we publish them:
+  ((moderation_info_url_en))
+
+  Thanks,
+  The Petitions team
+  The Scottish Parliament

--- a/spec/fixtures/notify/cbf205c3-9d3a-4d97-8dd6-c367ecaeb8cd.yml
+++ b/spec/fixtures/notify/cbf205c3-9d3a-4d97-8dd6-c367ecaeb8cd.yml
@@ -1,0 +1,19 @@
+id: "cbf205c3-9d3a-4d97-8dd6-c367ecaeb8cd"
+name: "email_confirmation_for_creator_en"
+subject: "Please confirm your email"
+body: |-
+  Click this link to confirm your email:
+
+  # ((action_en))
+
+  ((url_en))
+
+  After you have confirmed your email, we will check your petition to make sure it meets the petition criteria.
+  If it does, we’ll publish it and let you know. This usually takes a week or less.
+
+  Find out how we check petitions before we publish them:
+  ((moderation_info_url_gd))
+
+  Thanks,
+  The Petitions team
+  The Scottish Parliament


### PR DESCRIPTION
Scottish parliament does not require any sponsors for a petition to be moderated.

This adds that functionality, without getting rid of the sponsor functionality.

Petition creator will now be emailed to validate their email, and petition goes straight to sponsored state, once they have confirmed.