### PR TITLE
Adjust trigger for deploying to preview

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,8 @@
-name: Pull Request
+name: Build
 
 on:
+  push:
+    branches: [main]
   pull_request:
     branches: [main]
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -3,6 +3,7 @@ name: Deploy to Preview
 on:
   release:
     types: [prereleased]
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -2,7 +2,7 @@ name: Deploy to Preview
 
 on:
   release:
-    types: [created]
+    types: [prereleased]
 
 jobs:
   deploy:

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,70 +1,16 @@
 name: Deploy to Preview
 
 on:
-  push:
-    branches: [main]
+  release:
+    types: [created]
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-
-    services:
-      postgres:
-        image: postgres:10.7
-        ports: ["5432:5432"]
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-
-      memcached:
-        image: memcached:1.5.16
-        ports: ["11211:11211"]
-
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
-
-    - name: Setup ruby
-      uses: ruby/setup-ruby@v1
-      with:
-        ruby-version: 2.6
-
-    - name: Install postgres client
-      run: |
-        sudo apt-get -yqq install libpq-dev
-
-    - name: Setup gem cache
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-
-    - name: Install gems
-      run: |
-        gem install bundler -v 1.17.3
-        bundle install --jobs 4 --retry 3 --path vendor/bundle
-
-    - name: Setup database
-      env:
-        DATABASE_URL: postgres://postgres:@localhost:5432/spets_test
-        RAILS_ENV: test
-      run: |
-        bundle exec rake db:setup
-
-    - name: Run tests
-      env:
-        DATABASE_URL: postgres://postgres:@localhost:5432/spets_test
-        RAILS_ENV: test
-      run: |
-        bundle exec rake
-
   deploy:
     runs-on: ubuntu-latest
-    needs: [build]
+
+    environment:
+      name: scottish-petitions-preview
+      url: https://preview.scotpets.net/
 
     steps:
     - name: Checkout code


### PR DESCRIPTION
Under active development there may be multiple PRs being merged in rapid succession and each of these will trigger a deploy currently and there may be failures as only one deploy will work at a time.

By switching to deploying on release we can control when the deploy happens and batch up a group of changes to deployed at the same time.

The trigger is when the release is 'created' with the idea that we will create draft releases that deploy to preview automatically and then when we have a production environment we will publish the release to deploy to production.