### PR TITLE
Hide section that warns petitioners about the need to collect sponsors

### DIFF
--- a/app/views/petitions/check.html.erb
+++ b/app/views/petitions/check.html.erb
@@ -8,11 +8,13 @@
     <%= t(:"ui.petitions.action.help_html") %>
   </div>
 
-  <section class="create-warning" aria-labelledby="just-so-you-know-heading">
-    <h2 id="just-so-you-know-heading"><%= t(:"ui.petitions.need_sponsors_later_heading") %></h2>
-    <span aria-hidden="true"><%= Site.minimum_number_of_sponsors %></span>
-    <p><%= t(:"ui.petitions.need_sponsors_later", count: Site.minimum_number_of_sponsors) %></p>
-  </section>
+  <% if Site.collecting_sponsors? %>
+    <section class="create-warning" aria-labelledby="just-so-you-know-heading">
+      <h2 id="just-so-you-know-heading"><%= t(:"ui.petitions.need_sponsors_later_heading") %></h2>
+      <span aria-hidden="true"><%= Site.minimum_number_of_sponsors %></span>
+      <p><%= t(:"ui.petitions.need_sponsors_later", count: Site.minimum_number_of_sponsors) %></p>
+    </section>
+  <% end %>
 
   <%= t(:"ui.application.continue_html") %>
 </form>

--- a/app/views/petitions/thank_you.html.erb
+++ b/app/views/petitions/thank_you.html.erb
@@ -3,9 +3,13 @@
   <%= t(:"ui.petitions.thank_you.heading") %>
 </h1>
 
-<p class="lede"><%= t(:"ui.petitions.thank_you.link_emailed") %></p>
+<% if Site.collecting_sponsors? %>
+  <p class="lede"><%= t(:"ui.petitions.thank_you.link_emailed") %></p>
+  <h2><%= t(:"ui.petitions.thank_you.n_sponsors_needed_heading", count: Site.minimum_number_of_sponsors) %></h2>
+  <p><%= t(:"ui.petitions.thank_you.n_sponsors_needed", count: Site.minimum_number_of_sponsors) %></p>
 
-<h2><%= t(:"ui.petitions.thank_you.n_sponsors_needed_heading", count: Site.minimum_number_of_sponsors) %></h2>
-<p><%= t(:"ui.petitions.thank_you.n_sponsors_needed", count: Site.minimum_number_of_sponsors) %></p>
-
-<%= render 'notification', message: t(:"ui.petitions.thank_you.n_sponsors_needed_notice", count: Site.minimum_number_of_sponsors) %>
+  <%= render 'notification', message: t(:"ui.petitions.thank_you.n_sponsors_needed_notice", count: Site.minimum_number_of_sponsors) %>
+<% else %>
+  <p class="lede"><%= t(:"ui.petitions.thank_you.confirmation_link_emailed") %></p>
+  <p><%= t(:"ui.petitions.thank_you.confirmation_needed") %></p>
+<% end %>

--- a/config/locales/ui.en-GB.yml
+++ b/config/locales/ui.en-GB.yml
@@ -6,7 +6,7 @@ en-GB:
         <h1 class="page-title">A new petitions site is coming on 30 April</h1>
         <p>Sorry, the petitions service is currently unavailable. We are launching a new, improved website for petitions on 30 April.</p>
         <p>Please accept our apologies for any inconvenience.</p>
-        <p>Click here to find out more about the work of the <a href="https://beta.parliament.scot/chamber-and-committees/committees/current-committees/public-petitions-committee">Public Petitions Committee</a>.</p>      
+        <p>Click here to find out more about the work of the <a href="https://beta.parliament.scot/chamber-and-committees/committees/current-committees/public-petitions-committee">Public Petitions Committee</a>.</p>
     os:
       app_name: "Petitions"
       app_tooltip: "Scottish Parliament"
@@ -78,7 +78,7 @@ en-GB:
             body_html: |-
               <p>You can email the %{petitions_committee_link} directly.</p>
               <p>They can help you to understand how Parliament handles petitions. They can also provide a template for you to use to collect signatures on paper and help with some technical problems using this service. They can’t forward your feedback to the people who started a petition or comment on the ideas raised in a specific petition.</p>
-              <p>Email: <a href="mailto:petitionscommittee@parliament.scot">petitionscommittee@parliament.scot</a></p>            
+              <p>Email: <a href="mailto:petitionscommittee@parliament.scot">petitionscommittee@parliament.scot</a></p>
             petitions_committee_link: "Petitions Committee"
           phone:
             heading: "Phone"
@@ -488,6 +488,8 @@ en-GB:
       thank_you:
         heading: "One more step…"
         link_emailed: "We’ve emailed you a link to send to your potential supporters"
+        confirmation_link_emailed: "We’ve emailed you a link to confirm your email address"
+        confirmation_needed: "Please click the link in the email we have sent you to confirm your email address"
         n_sponsors_needed: |-
           %{count} people need to click this link and confirm their support for your petition to go live. Once this has happened the Petitions team will check that it meets the petitions standards and arrange for it to be translated. You will receive an email when it is published.
         n_sponsors_needed_notice: |-
@@ -755,7 +757,7 @@ en-GB:
           <h3>Our Contact Details</h3>
 
           <p>Any queries regarding our use of your information should be sent to the Data Protection Officer at:</p>
-  
+
           <p>dataprotection@parliament.scot 0131 348 6913</p>
 
           <h3>What data we collect from you</h3>
@@ -769,7 +771,7 @@ en-GB:
             <li>the country you live in</li>
             <li>the IP address you use when starting or signing a petition</li>
           </ul>
-  
+
           <p>In addition, for people who start a petition we will also collect:</p>
 
           <ul class="list-bullet">
@@ -777,9 +779,9 @@ en-GB:
             <li>your contact telephone number</li>
             <li>any personal information or details that you provide within the petition itself.</li>
           </ul>
-  
+
           <p>We sometimes receive information relating to people who have signed petitions on paper. Paper petitions are securely stored and retained for the same period as personal data received through our own electronic petitions system. They are destroyed in a secure manner at the end of the retention period.</p>
-  
+
           <h3>Why we need your data</h3>
 
           <p>We use this information to:</p>
@@ -816,7 +818,7 @@ en-GB:
           <p>If a petition you’ve started is referred to the Petitions Committee, we’ll use your contact details to update you about the petition’s progress and to offer you the opportunity to provide further information and engage with the Committee.</p>
 
           <p>You will receive automated confirmation emails when you set up or sign a petition.</p>
-  
+
           <p>If you’ve signed a petition, you can choose to receive updates about the progress of the petition. This might include contacting you to let you know what is happening in Parliament in relation to your petition, such as: debates that you can watch or read, chances to respond to a consultation, or ways to let committees and Members of the Scottish Parliament know why the petition is important to you.</p>
 
           <p>We may occasionally use your contact details to seek your views on Parliament’s petitions process.</p>
@@ -848,9 +850,9 @@ en-GB:
           <p>As such, personal data is processed on the basis that it is necessary for the performance of a task carried out in the public interest in accordance with Article 6(1)(e) of the General Data Protection Regulation (GDPR), read together with section 8(d) of the Data Protection Act 2018.</p>
 
           <p>Where we are required to process personal data in order to comply with a legal obligation, such as a request under access to information legislation or a court order, we will do so on the basis that processing is necessary for compliance with a legal obligation pursuant to Article 6(1)(c) of the GDPR.</p>
-  
+
           <p>We may process personal data relating to criminal convictions and offences. In order to comply with Article 10 of the GDPR, this data will be processed in accordance with our Article 6 legal basis, as outlined above, and section 10 of, and paragraph 6 of Schedule 1 to, the Data Protection Act 2018.</p>
-  
+
           <p>Finally, we may process special categories of personal data of those who start or sign a petition, and/or contribute to its passage through Parliament’s petitions process. Special category personal data is defined in Article 9(1) of the GDPR as the processing of personal data revealing racial or ethnic origin, political opinions, religious or philosophical beliefs, or trade-union membership, and the processing of genetic data, biometric data for the purpose of uniquely identifying a natural person, data concerning health or a natural person’s sex life or sexual orientation.</p>
 
           <p>Special category personal data will usually be processed on the basis that it is necessary for reasons of substantial public interest, pursuant to Article 9(2)(g) of the GDPR read in conjunction with section 10 of, and paragraph 6 of Schedule 1 to, the Data Protection Act 2018. However, where your special category personal data is made public by you, it may be processed on the basis that it has already been manifestly made public by you, pursuant to Article 9(2)(e) of the GDPR.</p>
@@ -862,7 +864,7 @@ en-GB:
           <h3>What are your rights</h3>
 
           <p>You have certain rights over the information we hold. In summary, the rights include:</p>
-  
+
           <ul class="list-bullet">
             <li>The right to be informed about how your personal information is used;</li>
             <li>The right of access to copies of your personal information;</li>
@@ -874,7 +876,7 @@ en-GB:
           <p>If you would like to engage any of these rights, please email dataprotection@parliament.scot</p>
 
           <h3>Changes to this notice</h3>
-  
+
           <p>We may change this privacy notice. In that case the ‘last updated’ date at the top of this page will also change. Any changes to this privacy notice will apply to you and your data immediately. If these changes affect how your personal data is processed, we will take reasonable steps to make sure you know.</p>
 
           <h3>How to complain</h3>

--- a/config/locales/ui.gd-GB.yml
+++ b/config/locales/ui.gd-GB.yml
@@ -6,7 +6,7 @@ gd-GB:
         <h1 class="page-title">A new petitions site is coming on 30 April</h1>
         <p>Sorry, the petitions service is currently unavailable. We are launching a new, improved website for petitions on 30 April.</p>
         <p>Please accept our apologies for any inconvenience.</p>
-        <p>Click here to find out more about the work of the <a href="https://beta.parliament.scot/chamber-and-committees/committees/current-committees/public-petitions-committee">Public Petitions Committee</a>.</p>      
+        <p>Click here to find out more about the work of the <a href="https://beta.parliament.scot/chamber-and-committees/committees/current-committees/public-petitions-committee">Public Petitions Committee</a>.</p>
     os:
       app_name: "Petitions"
       app_tooltip: "Scottish Parliament"
@@ -78,7 +78,7 @@ gd-GB:
             body_html: |-
               <p>You can email the %{petitions_committee_link} directly.</p>
               <p>They can help you to understand how Parliament handles petitions. They can also provide a template for you to use to collect signatures on paper and help with some technical problems using this service. They can’t forward your feedback to the people who started a petition or comment on the ideas raised in a specific petition.</p>
-              <p>Email: <a href="mailto:petitionscommittee@parliament.scot">petitionscommittee@parliament.scot</a></p>            
+              <p>Email: <a href="mailto:petitionscommittee@parliament.scot">petitionscommittee@parliament.scot</a></p>
             petitions_committee_link: "Petitions Committee"
           phone:
             heading: "Phone"
@@ -488,6 +488,8 @@ gd-GB:
       thank_you:
         heading: "One more step…"
         link_emailed: "We’ve emailed you a link to send to your potential supporters"
+        confirmation_link_emailed: "We’ve emailed you a link to confirm your email address"
+        confirmation_needed: "Please click the link in the email we have sent you to confirm your email address"
         n_sponsors_needed: |-
           %{count} people need to click this link and confirm their support for your petition to go live. Once this has happened the Petitions team will check that it meets the petitions standards and arrange for it to be translated. You will receive an email when it is published.
         n_sponsors_needed_notice: |-
@@ -755,7 +757,7 @@ gd-GB:
           <h3>Our Contact Details</h3>
 
           <p>Any queries regarding our use of your information should be sent to the Data Protection Officer at:</p>
-  
+
           <p>dataprotection@parliament.scot 0131 348 6913</p>
 
           <h3>What data we collect from you</h3>
@@ -769,7 +771,7 @@ gd-GB:
             <li>the country you live in</li>
             <li>the IP address you use when starting or signing a petition</li>
           </ul>
-  
+
           <p>In addition, for people who start a petition we will also collect:</p>
 
           <ul class="list-bullet">
@@ -777,9 +779,9 @@ gd-GB:
             <li>your contact telephone number</li>
             <li>any personal information or details that you provide within the petition itself.</li>
           </ul>
-  
+
           <p>We sometimes receive information relating to people who have signed petitions on paper. Paper petitions are securely stored and retained for the same period as personal data received through our own electronic petitions system. They are destroyed in a secure manner at the end of the retention period.</p>
-  
+
           <h3>Why we need your data</h3>
 
           <p>We use this information to:</p>
@@ -816,7 +818,7 @@ gd-GB:
           <p>If a petition you’ve started is referred to the Petitions Committee, we’ll use your contact details to update you about the petition’s progress and to offer you the opportunity to provide further information and engage with the Committee.</p>
 
           <p>You will receive automated confirmation emails when you set up or sign a petition.</p>
-  
+
           <p>If you’ve signed a petition, you can choose to receive updates about the progress of the petition. This might include contacting you to let you know what is happening in Parliament in relation to your petition, such as: debates that you can watch or read, chances to respond to a consultation, or ways to let committees and Members of the Scottish Parliament know why the petition is important to you.</p>
 
           <p>We may occasionally use your contact details to seek your views on Parliament’s petitions process.</p>
@@ -848,9 +850,9 @@ gd-GB:
           <p>As such, personal data is processed on the basis that it is necessary for the performance of a task carried out in the public interest in accordance with Article 6(1)(e) of the General Data Protection Regulation (GDPR), read together with section 8(d) of the Data Protection Act 2018.</p>
 
           <p>Where we are required to process personal data in order to comply with a legal obligation, such as a request under access to information legislation or a court order, we will do so on the basis that processing is necessary for compliance with a legal obligation pursuant to Article 6(1)(c) of the GDPR.</p>
-  
+
           <p>We may process personal data relating to criminal convictions and offences. In order to comply with Article 10 of the GDPR, this data will be processed in accordance with our Article 6 legal basis, as outlined above, and section 10 of, and paragraph 6 of Schedule 1 to, the Data Protection Act 2018.</p>
-  
+
           <p>Finally, we may process special categories of personal data of those who start or sign a petition, and/or contribute to its passage through Parliament’s petitions process. Special category personal data is defined in Article 9(1) of the GDPR as the processing of personal data revealing racial or ethnic origin, political opinions, religious or philosophical beliefs, or trade-union membership, and the processing of genetic data, biometric data for the purpose of uniquely identifying a natural person, data concerning health or a natural person’s sex life or sexual orientation.</p>
 
           <p>Special category personal data will usually be processed on the basis that it is necessary for reasons of substantial public interest, pursuant to Article 9(2)(g) of the GDPR read in conjunction with section 10 of, and paragraph 6 of Schedule 1 to, the Data Protection Act 2018. However, where your special category personal data is made public by you, it may be processed on the basis that it has already been manifestly made public by you, pursuant to Article 9(2)(e) of the GDPR.</p>
@@ -862,7 +864,7 @@ gd-GB:
           <h3>What are your rights</h3>
 
           <p>You have certain rights over the information we hold. In summary, the rights include:</p>
-  
+
           <ul class="list-bullet">
             <li>The right to be informed about how your personal information is used;</li>
             <li>The right of access to copies of your personal information;</li>
@@ -874,7 +876,7 @@ gd-GB:
           <p>If you would like to engage any of these rights, please email dataprotection@parliament.scot</p>
 
           <h3>Changes to this notice</h3>
-  
+
           <p>We may change this privacy notice. In that case the ‘last updated’ date at the top of this page will also change. Any changes to this privacy notice will apply to you and your data immediately. If these changes affect how your personal data is processed, we will take reasonable steps to make sure you know.</p>
 
           <h3>How to complain</h3>

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -60,6 +60,7 @@ Scenario: Charlie creates a petition with a custom closing date
 Scenario: Charlie creates a petition when sponsor count is set to 0
   Given the site is not collecting sponsors
   And I start a new petition
+  Then I should not see "email addresses for 0 supporters"
   And I fill in the petition details
   And I press "Preview petition"
   And I press "This looks good"
@@ -72,10 +73,12 @@ Scenario: Charlie creates a petition when sponsor count is set to 0
   When I press "Yes – this is my email address"
   Then a petition should exist with action_en: "The wombats of wimbledon rock.", action_gd: nil, state: "pending", locale: "en-GB"
   And there should be a "pending" signature with email "womboid@wimbledon.com" and name "Womboid Wibbledon"
+  Then I should see "We’ve emailed you a link to confirm your email address"
   And "Womboid Wibbledon" wants to be notified about the petition's progress
   And "womboid@wimbledon.com" should be emailed a link for validating their signature
   When I confirm my email
   Then a petition should exist with action_en: "The wombats of wimbledon rock.", state: "sponsored"
+  Then I should see "We’re checking this petition"
 
 @gaelic
 Scenario: Charlie creates a petition in Gaelic


### PR DESCRIPTION
Scottish Parliament does not require petitions to collect sponsors, so this should not be shown as a warning in the create a petition journey