### PR TITLE
Update signature count immediately on verification

### DIFF
--- a/app/controllers/petitioners_controller.rb
+++ b/app/controllers/petitioners_controller.rb
@@ -3,6 +3,7 @@ class PetitionersController < SponsorsController
 
   def verify
     @petition.validate_creator!
+    @petition.increment_signature_count!
 
     redirect_to moderation_info_petition_url(@petition)
   end


### PR DESCRIPTION
Previously the email verification link was redirecting to the wrong page because the signature count had not been updated in time. This does it immediately, ensuring the petitioner gets sent to the correct page