### PR TITLE
Add the option to disable the Gaelic website

### DIFF
--- a/app/controllers/admin/petition_emails_controller.rb
+++ b/app/controllers/admin/petition_emails_controller.rb
@@ -25,7 +25,7 @@ class Admin::PetitionEmailsController < Admin::AdminController
 
       redirect_to [:admin, @petition, :emails], notice: message
     else
-      render :new
+      render :new, alert: :unable_to_create_petition_email
     end
   end
 

--- a/app/controllers/admin/sites_controller.rb
+++ b/app/controllers/admin/sites_controller.rb
@@ -34,7 +34,8 @@ class Admin::SitesController < Admin::AdminController
       :signature_count_interval, :update_signature_counts,
       :disable_trending_petitions, :threshold_for_moderation_delay,
       :disable_invalid_signature_count_check, :disable_daily_update_statistics_job,
-      :disable_plus_address_check, :disable_feedback_sending, :show_holding_page
+      :disable_plus_address_check, :disable_feedback_sending, :show_holding_page,
+      :disable_gaelic_website
     )
   end
 end

--- a/app/controllers/localized_controller.rb
+++ b/app/controllers/localized_controller.rb
@@ -7,6 +7,7 @@ class LocalizedController < ApplicationController
 
   before_action :set_locale
   before_action :set_bypass_cookie, if: :bypass_param?
+  before_action :redirect_to_english_page, if: :gaelic_disabled?
   before_action :redirect_to_holding_page, except: :holding
   before_action :redirect_to_home_page, only: :holding
 
@@ -25,6 +26,18 @@ class LocalizedController < ApplicationController
     else
       :"en-GB"
     end
+  end
+
+  def english_url?
+    params[:locale] == "en-GB"
+  end
+
+  def english_url
+    URI.parse(request.original_url).tap do |uri|
+      uri.host = Site.host_en
+    end.to_s
+  rescue URI::InvalidURIError => e
+    home_en_url
   end
 
   def holding_page?
@@ -52,6 +65,14 @@ class LocalizedController < ApplicationController
       cookies.signed[:_spets_bypass] = Site.bypass_token
       redirect_to home_url
     end
+  end
+
+  def gaelic_disabled?
+    Site.disable_gaelic_website?
+  end
+
+  def redirect_to_english_page
+    redirect_to english_url unless english_url?
   end
 
   def redirect_to_home_page

--- a/app/helpers/translation_helper.rb
+++ b/app/helpers/translation_helper.rb
@@ -51,6 +51,10 @@ module TranslationHelper
     LanguageSwitcherTag.new(self).render
   end
 
+  def show_language_switcher?
+    request.present? && !Site.disable_gaelic_website?
+  end
+
   if Site.translation_enabled?
     def t(key, options = {})
       keys = I18n.normalize_keys(I18n.locale, key, options[:scope])

--- a/app/models/concerns/translatable.rb
+++ b/app/models/concerns/translatable.rb
@@ -79,4 +79,8 @@ module Translatable
   def translated_method(english, gaelic, *args)
     public_send(I18n.locale == :"en-GB" ? english : gaelic, *args)
   end
+
+  def gaelic_disabled?
+    Site.disable_gaelic_website?
+  end
 end

--- a/app/models/paper_petition.rb
+++ b/app/models/paper_petition.rb
@@ -23,23 +23,38 @@ class PaperPetition
 
   with_options presence: true do
     validates :action_en, :background_en
-    validates :action_gd, :background_gd
     validates :locale, :location_code
     validates :signature_count, :submitted_on
     validates :name, :email, :phone_number
     validates :address, :postcode
+
+    with_options unless: :gaelic_disabled? do
+      validates :action_gd, :background_gd
+    end
   end
 
   with_options length: { maximum: 100 } do
-    validates :action_en, :action_gd
+    validates :action_en
+
+    with_options unless: :gaelic_disabled? do
+      validates :action_gd
+    end
   end
 
   with_options length: { maximum: 500 } do
-    validates :background_en, :background_gd, :address
+    validates :background_en, :address
+
+    with_options unless: :gaelic_disabled? do
+      validates :background_gd
+    end
   end
 
   with_options length: { maximum: 1100 } do
-    validates :additional_details_en, :additional_details_gd
+    validates :additional_details_en
+
+    with_options unless: :gaelic_disabled? do
+      validates :additional_details_gd
+    end
   end
 
   with_options length: { maximum: 255 } do
@@ -48,8 +63,11 @@ class PaperPetition
 
   with_options format: { with: /\A[^-=+@]/, allow_blank: true } do
     validates :action_en, :background_en, :additional_details_en
-    validates :action_gd, :background_gd, :additional_details_gd
     validates :name, :phone_number, :address
+
+    with_options unless: :gaelic_disabled? do
+      validates :action_gd, :background_gd, :additional_details_gd
+    end
   end
 
   validates :locale, inclusion: { in: %w[en-GB gd-GB] }
@@ -159,5 +177,9 @@ class PaperPetition
 
   def debate_threshold_reached_at
     signature_count >= threshold_for_debate ? closed_at : nil
+  end
+
+  def gaelic_disabled?
+    Site.disable_gaelic_website?
   end
 end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -649,7 +649,7 @@ class Petition < ActiveRecord::Base
   end
 
   def translated?
-    english_translated? && gaelic_translated?
+    english_translated? && gaelic_translated? || gaelic_disabled?
   end
 
   def english_translated?

--- a/app/models/petition/email.rb
+++ b/app/models/petition/email.rb
@@ -7,7 +7,12 @@ class Petition < ActiveRecord::Base
     translate :subject, :body
 
     validates :petition, presence: true
-    validates :subject_en, :subject_gd, presence: true, length: { maximum: 100 }
-    validates :body_en, :body_gd, presence: true, length: { maximum: 5000 }
+    validates :subject_en, presence: true, length: { maximum: 100 }
+    validates :body_en, presence: true, length: { maximum: 5000 }
+
+    with_options unless: :gaelic_disabled? do
+      validates :subject_gd, presence: true, length: { maximum: 100 }
+      validates :body_gd, presence: true, length: { maximum: 5000 }
+    end
   end
 end

--- a/app/models/rejection.rb
+++ b/app/models/rejection.rb
@@ -8,7 +8,11 @@ class Rejection < ActiveRecord::Base
 
   validates :petition, presence: true
   validates :code, presence: true, inclusion: { in: :rejection_codes }
-  validates :details_en, :details_gd, length: { maximum: 4000 }, allow_blank: true
+  validates :details_en, length: { maximum: 4000 }, allow_blank: true
+
+  with_options unless: :gaelic_disabled? do
+    validates :details_gd, length: { maximum: 4000 }, allow_blank: true
+  end
 
   attr_writer :rejected_at
 

--- a/app/models/rejection_reason.rb
+++ b/app/models/rejection_reason.rb
@@ -10,7 +10,10 @@ class RejectionReason < ActiveRecord::Base
 
   with_options presence: true do
     validates :description_en, length: { maximum: 1000 }
-    validates :description_gd, length: { maximum: 1000 }
+
+    with_options unless: :gaelic_disabled? do
+      validates :description_gd, length: { maximum: 1000 }
+    end
   end
 
   before_destroy do

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -19,6 +19,7 @@ class Site < ActiveRecord::Base
     disable_daily_update_statistics_job
     disable_plus_address_check
     disable_feedback_sending
+    disable_gaelic_website
     show_holding_page
   ]
 

--- a/app/models/topic.rb
+++ b/app/models/topic.rb
@@ -7,8 +7,11 @@ class Topic < ActiveRecord::Base
   translate :code, :name
 
   with_options presence: true, uniqueness: true do
-    validates :code_en, :code_gd, length: { maximum: 100 }
-    validates :name_en, :name_gd, length: { maximum: 100 }
+    validates :code_en, :name_en, length: { maximum: 100 }
+
+    with_options unless: :gaelic_disabled? do
+      validates :code_gd, :name_gd, length: { maximum: 100 }
+    end
   end
 
   after_destroy :remove_topic_from_petitions

--- a/app/views/admin/abms_link/_petition_action_abms_link.html.erb
+++ b/app/views/admin/abms_link/_petition_action_abms_link.html.erb
@@ -2,16 +2,24 @@
 
 <%= form_for petition, url: admin_petition_abms_link_path(petition), method: :patch do |f| %>
 
-  <%= form_row :for => [f.object, :abms_link_en] do %>
-    <%= f.label :abms_link_en, "English", class: 'form-label' %>
-    <%= error_messages_for_field f.object, :abms_link_en %>
-    <%= f.text_field :abms_link_en, tabindex: increment, class: 'form-control' %>
-  <% end %>
+  <% if Site.disable_gaelic_website? %>
+    <%= form_row :for => [f.object, :abms_link_en] do %>
+      <%= f.label :abms_link_en, "ABMS link", class: 'form-label visuallyhidden' %>
+      <%= error_messages_for_field f.object, :abms_link_en %>
+      <%= f.text_field :abms_link_en, tabindex: increment, class: 'form-control' %>
+    <% end %>
+  <% else %>
+    <%= form_row :for => [f.object, :abms_link_en] do %>
+      <%= f.label :abms_link_en, "English", class: 'form-label' %>
+      <%= error_messages_for_field f.object, :abms_link_en %>
+      <%= f.text_field :abms_link_en, tabindex: increment, class: 'form-control' %>
+    <% end %>
 
-  <%= form_row :for => [f.object, :abms_link_gd], style: "margin-top: -15px;" do %>
-    <%= f.label :abms_link_gd, "Gaelic", class: 'form-label' %>
-    <%= error_messages_for_field f.object, :abms_link_gd %>
-    <%= f.text_field :abms_link_gd, tabindex: increment, class: 'form-control' %>
+    <%= form_row :for => [f.object, :abms_link_gd], style: "margin-top: -15px;" do %>
+      <%= f.label :abms_link_gd, "Gaelic", class: 'form-label' %>
+      <%= error_messages_for_field f.object, :abms_link_gd %>
+      <%= f.text_field :abms_link_gd, tabindex: increment, class: 'form-control' %>
+    <% end %>
   <% end %>
 
   <%= f.submit "Save", name: 'save', class: 'button' %>

--- a/app/views/admin/debate_outcomes/_petition_action_debate_outcome.html.erb
+++ b/app/views/admin/debate_outcomes/_petition_action_debate_outcome.html.erb
@@ -1,15 +1,23 @@
 <h2 class="petition-action-heading">Debate Outcome</h2>
 <%= form_for petition.debate_outcome, url: admin_petition_debate_outcome_path(petition), method: :patch do |f| -%>
-  <%= form_row for: [f.object, :overview_en] do %>
-    <%= f.label :overview_en, "Overview  (English)", class: 'form-label' %>
-    <%= error_messages_for_field f.object, :overview_en %>
-    <%= f.text_area :overview_en, tabindex: increment, class: 'form-control' %>
-  <% end %>
+  <% if Site.disable_gaelic_website? %>
+    <%= form_row for: [f.object, :overview_en] do %>
+      <%= f.label :overview_en, "Overview", class: 'form-label' %>
+      <%= error_messages_for_field f.object, :overview_en %>
+      <%= f.text_area :overview_en, tabindex: increment, class: 'form-control' %>
+    <% end %>
+  <% else %>
+    <%= form_row for: [f.object, :overview_en] do %>
+      <%= f.label :overview_en, "Overview  (English)", class: 'form-label' %>
+      <%= error_messages_for_field f.object, :overview_en %>
+      <%= f.text_area :overview_en, tabindex: increment, class: 'form-control' %>
+    <% end %>
 
-  <%= form_row for: [f.object, :overview_gd] do %>
-    <%= f.label :overview_gd, "Overview  (Gaelic)", class: 'form-label' %>
-    <%= error_messages_for_field f.object, :overview_gd %>
-    <%= f.text_area :overview_gd, tabindex: increment, class: 'form-control' %>
+    <%= form_row for: [f.object, :overview_gd] do %>
+      <%= f.label :overview_gd, "Overview  (Gaelic)", class: 'form-label' %>
+      <%= error_messages_for_field f.object, :overview_gd %>
+      <%= f.text_area :overview_gd, tabindex: increment, class: 'form-control' %>
+    <% end %>
   <% end %>
 
   <h3 class="petition-action-subheading">Was this petition debated?</h3>
@@ -34,40 +42,60 @@
       <%= f.date_field :debated_on, tabindex: increment, class: 'form-control' %>
     <% end %>
 
-    <%= form_row for: [f.object, :transcript_url_en] do %>
-      <%= f.label :transcript_url_en, 'Transcript URL (English)', class: 'form-label' %>
-      <%= error_messages_for_field f.object, :transcript_url_en %>
-      <%= f.url_field :transcript_url_en, tabindex: increment, class: 'form-control' %>
-    <% end %>
+    <% if Site.disable_gaelic_website? %>
+      <%= form_row for: [f.object, :transcript_url_en] do %>
+        <%= f.label :transcript_url_en, 'Transcript URL', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :transcript_url_en %>
+        <%= f.url_field :transcript_url_en, tabindex: increment, class: 'form-control' %>
+      <% end %>
 
-    <%= form_row for: [f.object, :transcript_url_gd] do %>
-      <%= f.label :transcript_url_gd, 'Transcript URL (Gaelic)', class: 'form-label' %>
-      <%= error_messages_for_field f.object, :transcript_url_gd %>
-      <%= f.url_field :transcript_url_gd, tabindex: increment, class: 'form-control' %>
-    <% end %>
+      <%= form_row for: [f.object, :video_url_en] do %>
+        <%= f.label :video_url_en, 'Video URL', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :video_url_en %>
+        <%= f.url_field :video_url_en, tabindex: increment, class: 'form-control' %>
+      <% end %>
 
-    <%= form_row for: [f.object, :video_url_en] do %>
-      <%= f.label :video_url_en, 'Video URL (English)', class: 'form-label' %>
-      <%= error_messages_for_field f.object, :video_url_en %>
-      <%= f.url_field :video_url_en, tabindex: increment, class: 'form-control' %>
-    <% end %>
+      <%= form_row for: [f.object, :debate_pack_url_en] do %>
+        <%= f.label :debate_pack_url_en, 'Debate Pack URL', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :debate_pack_url_en %>
+        <%= f.url_field :debate_pack_url_en, tabindex: increment, class: 'form-control' %>
+      <% end %>
+    <% else %>
+      <%= form_row for: [f.object, :transcript_url_en] do %>
+        <%= f.label :transcript_url_en, 'Transcript URL (English)', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :transcript_url_en %>
+        <%= f.url_field :transcript_url_en, tabindex: increment, class: 'form-control' %>
+      <% end %>
 
-    <%= form_row for: [f.object, :video_url_gd] do %>
-      <%= f.label :video_url_gd, 'Video URL (Gaelic)', class: 'form-label' %>
-      <%= error_messages_for_field f.object, :video_url_gd %>
-      <%= f.url_field :video_url_gd, tabindex: increment, class: 'form-control' %>
-    <% end %>
+      <%= form_row for: [f.object, :transcript_url_gd] do %>
+        <%= f.label :transcript_url_gd, 'Transcript URL (Gaelic)', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :transcript_url_gd %>
+        <%= f.url_field :transcript_url_gd, tabindex: increment, class: 'form-control' %>
+      <% end %>
 
-    <%= form_row for: [f.object, :debate_pack_url_en] do %>
-      <%= f.label :debate_pack_url_en, 'Debate Pack URL (English)', class: 'form-label' %>
-      <%= error_messages_for_field f.object, :debate_pack_url_en %>
-      <%= f.url_field :debate_pack_url_en, tabindex: increment, class: 'form-control' %>
-    <% end %>
+      <%= form_row for: [f.object, :video_url_en] do %>
+        <%= f.label :video_url_en, 'Video URL (English)', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :video_url_en %>
+        <%= f.url_field :video_url_en, tabindex: increment, class: 'form-control' %>
+      <% end %>
 
-    <%= form_row for: [f.object, :debate_pack_url_gd] do %>
-      <%= f.label :debate_pack_url_gd, 'Debate Pack URL (Gaelic)', class: 'form-label' %>
-      <%= error_messages_for_field f.object, :debate_pack_url_gd %>
-      <%= f.url_field :debate_pack_url_gd, tabindex: increment, class: 'form-control' %>
+      <%= form_row for: [f.object, :video_url_gd] do %>
+        <%= f.label :video_url_gd, 'Video URL (Gaelic)', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :video_url_gd %>
+        <%= f.url_field :video_url_gd, tabindex: increment, class: 'form-control' %>
+      <% end %>
+
+      <%= form_row for: [f.object, :debate_pack_url_en] do %>
+        <%= f.label :debate_pack_url_en, 'Debate Pack URL (English)', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :debate_pack_url_en %>
+        <%= f.url_field :debate_pack_url_en, tabindex: increment, class: 'form-control' %>
+      <% end %>
+
+      <%= form_row for: [f.object, :debate_pack_url_gd] do %>
+        <%= f.label :debate_pack_url_gd, 'Debate Pack URL (Gaelic)', class: 'form-label' %>
+        <%= error_messages_for_field f.object, :debate_pack_url_gd %>
+        <%= f.url_field :debate_pack_url_gd, tabindex: increment, class: 'form-control' %>
+      <% end %>
     <% end %>
 
     <%= form_row for: [f.object, :commons_image] do %>

--- a/app/views/admin/paper_petitions/new.html.erb
+++ b/app/views/admin/paper_petitions/new.html.erb
@@ -4,7 +4,11 @@
   <div class="grid-row">
     <div class="column-two-thirds extra-gutter">
       <fieldset id="english-details">
-        <legend><h2>Petition details in English</h2></legend>
+        <% if Site.disable_gaelic_website? %>
+          <legend><h2>Petition details</h2></legend>
+        <% else %>
+          <legend><h2>Petition details in English</h2></legend>
+        <% end %>
         <%= form_row for: [form.object, :action_en] do %>
           <%= form.label :action_en, "Action", class: "form-label" %>
           <%= error_messages_for_field @paper_petition, :action_en %>
@@ -32,35 +36,37 @@
         <% end %>
       </fieldset>
 
-      <fieldset id="gaelic-details">
-        <legend><h2>Petition details in Gaelic</h2></legend>
-        <%= form_row for: [form.object, :action_gd] do %>
-          <%= form.label :action_gd, "Action", class: "form-label" %>
-          <%= error_messages_for_field @paper_petition, :action_gd %>
-          <%= form.text_area :action_gd, tabindex: increment, rows: 3, class: "form-control", data: { max_length: 100 } %>
-          <p class="character-count">100 characters max</p>
-        <% end %>
-
-        <%= form_row for: [form.object, :background_gd] do %>
-          <%= form.label :background_gd, "Background", class: "form-label" %>
-          <%= error_messages_for_field @paper_petition, :background_gd %>
-          <%= form.text_area :background_gd, tabindex: increment, rows: 5, class: "form-control", data: { max_length: 500 } %>
-          <p class="character-count">500 characters max</p>
-        <% end %>
-
-        <%= content_tag :details, open: @paper_petition.additional_details_gd? do %>
-          <summary>
-            <%= form.label :additional_details_gd, "Additional details" %>
-          </summary>
-
-          <%= form_row for: [form.object, :additional_details_gd] do %>
-            <%= form.label :additional_details_gd, "Additional details", class: "form-label" %>
-            <%= error_messages_for_field @paper_petition, :additional_details_gd %>
-            <%= form.text_area :additional_details_gd, tabindex: increment, rows: 7, class: "form-control", data: { max_length: 1100 } %>
-            <p class="character-count">1100 characters max</p>
+      <% unless Site.disable_gaelic_website? %>
+        <fieldset id="gaelic-details">
+          <legend><h2>Petition details in Gaelic</h2></legend>
+          <%= form_row for: [form.object, :action_gd] do %>
+            <%= form.label :action_gd, "Action", class: "form-label" %>
+            <%= error_messages_for_field @paper_petition, :action_gd %>
+            <%= form.text_area :action_gd, tabindex: increment, rows: 3, class: "form-control", data: { max_length: 100 } %>
+            <p class="character-count">100 characters max</p>
           <% end %>
-        <% end %>
-      </fieldset>
+
+          <%= form_row for: [form.object, :background_gd] do %>
+            <%= form.label :background_gd, "Background", class: "form-label" %>
+            <%= error_messages_for_field @paper_petition, :background_gd %>
+            <%= form.text_area :background_gd, tabindex: increment, rows: 5, class: "form-control", data: { max_length: 500 } %>
+            <p class="character-count">500 characters max</p>
+          <% end %>
+
+          <%= content_tag :details, open: @paper_petition.additional_details_gd? do %>
+            <summary>
+              <%= form.label :additional_details_gd, "Additional details" %>
+            </summary>
+
+            <%= form_row for: [form.object, :additional_details_gd] do %>
+              <%= form.label :additional_details_gd, "Additional details", class: "form-label" %>
+              <%= error_messages_for_field @paper_petition, :additional_details_gd %>
+              <%= form.text_area :additional_details_gd, tabindex: increment, rows: 7, class: "form-control", data: { max_length: 1100 } %>
+              <p class="character-count">1100 characters max</p>
+            <% end %>
+          <% end %>
+        </fieldset>
+      <% end %>
 
       <h3>What language was this petition submitted in?</h3>
 

--- a/app/views/admin/petition_details/show.html.erb
+++ b/app/views/admin/petition_details/show.html.erb
@@ -5,13 +5,15 @@
   <div class="column-two-thirds extra-gutter">
     <h2 class="petition-action-heading">Edit petition</h2>
 
-    <p class="tabs">
-      <% if petition_locale == :"en-GB" %>
-        English | <%= link_to "Gaelic", admin_petition_details_path(locale: "gd-GB") %>
-      <% else %>
-        <%= link_to "English", admin_petition_details_path(locale: "en-GB") %> | Gaelic
-      <% end %>
-    </p>
+    <% unless Site.disable_gaelic_website? %>
+      <p class="tabs">
+        <% if petition_locale == :"en-GB" %>
+          English | <%= link_to "Gaelic", admin_petition_details_path(locale: "gd-GB") %>
+        <% else %>
+          <%= link_to "English", admin_petition_details_path(locale: "en-GB") %> | Gaelic
+        <% end %>
+      </p>
+    <% end %>
 
     <%= form_for @petition, url: admin_petition_details_path(@petition), method: :patch do |f| %>
       <%= hidden_field_tag :locale, petition_locale %>

--- a/app/views/admin/petition_emails/_form.html.erb
+++ b/app/views/admin/petition_emails/_form.html.erb
@@ -1,29 +1,45 @@
-<%= form_row for: [form.object, :subject_en] do %>
-  <%= form.label :subject_en, "Subject in English", class: "form-label" %>
-  <%= error_messages_for_field form.object, :subject_en %>
-  <%= form.text_area :subject_en, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: "form-control" %>
-  <p class="character-count">100 characters max</p>
-<% end %>
+<% if Site.disable_gaelic_website? %>
+  <%= form_row for: [form.object, :subject_en] do %>
+    <%= form.label :subject_en, "Subject", class: "form-label" %>
+    <%= error_messages_for_field form.object, :subject_en %>
+    <%= form.text_area :subject_en, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: "form-control" %>
+    <p class="character-count">100 characters max</p>
+  <% end %>
 
-<%= form_row for: [form.object, :subject_gd] do %>
-  <%= form.label :subject_gd, "Subject in Gaelic", class: "form-label" %>
-  <%= error_messages_for_field form.object, :subject_gd %>
-  <%= form.text_area :subject_gd, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: "form-control" %>
-  <p class="character-count">100 characters max</p>
-<% end %>
+  <%= form_row for: [form.object, :body_en] do %>
+    <%= form.label :body_en, "Body", class: "form-label" %>
+    <%= error_messages_for_field form.object, :body_en %>
+    <%= form.text_area :body_en, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: "form-control" %>
+    <p class="character-count">5000 characters max</p>
+  <% end %>
+<% else %>
+  <%= form_row for: [form.object, :subject_en] do %>
+    <%= form.label :subject_en, "Subject in English", class: "form-label" %>
+    <%= error_messages_for_field form.object, :subject_en %>
+    <%= form.text_area :subject_en, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: "form-control" %>
+    <p class="character-count">100 characters max</p>
+  <% end %>
 
-<%= form_row for: [form.object, :body_en] do %>
-  <%= form.label :body_en, "Body in English", class: "form-label" %>
-  <%= error_messages_for_field form.object, :body_en %>
-  <%= form.text_area :body_en, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: "form-control" %>
-  <p class="character-count">5000 characters max</p>
-<% end %>
+  <%= form_row for: [form.object, :subject_gd] do %>
+    <%= form.label :subject_gd, "Subject in Gaelic", class: "form-label" %>
+    <%= error_messages_for_field form.object, :subject_gd %>
+    <%= form.text_area :subject_gd, rows: 2, cols: 70, tabindex: increment, data: { max_length: 100 }, class: "form-control" %>
+    <p class="character-count">100 characters max</p>
+  <% end %>
 
-<%= form_row for: [form.object, :body_gd] do %>
-  <%= form.label :body_gd, "Body in Gaelic", class: "form-label" %>
-  <%= error_messages_for_field form.object, :body_gd %>
-  <%= form.text_area :body_gd, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: "form-control" %>
-  <p class="character-count">5000 characters max</p>
+  <%= form_row for: [form.object, :body_en] do %>
+    <%= form.label :body_en, "Body in English", class: "form-label" %>
+    <%= error_messages_for_field form.object, :body_en %>
+    <%= form.text_area :body_en, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: "form-control" %>
+    <p class="character-count">5000 characters max</p>
+  <% end %>
+
+  <%= form_row for: [form.object, :body_gd] do %>
+    <%= form.label :body_gd, "Body in Gaelic", class: "form-label" %>
+    <%= error_messages_for_field form.object, :body_gd %>
+    <%= form.text_area :body_gd, rows: 8, cols: 70, tabindex: increment, data: { max_length: 5000 }, class: "form-control" %>
+    <p class="character-count">5000 characters max</p>
+  <% end %>
 <% end %>
 
 <%= form.submit "Send email", name: "save_and_email", class: "button" %>

--- a/app/views/admin/petitions/_petition_content.html.erb
+++ b/app/views/admin/petitions/_petition_content.html.erb
@@ -29,9 +29,13 @@
 </div>
 
 <p class="edit-petition-link">
-  Edit petition:
-  <%= link_to 'English', admin_petition_details_path(@petition, locale: "en-GB") %> |
-  <%= link_to 'Gaelic', admin_petition_details_path(@petition, locale: "gd-GB") %>
+  <% if Site.disable_gaelic_website? %>
+    <%= link_to 'Edit details', admin_petition_details_path(@petition, locale: "en-GB") %>
+  <% else %>
+    Edit petition:
+    <%= link_to 'English', admin_petition_details_path(@petition, locale: "en-GB") %> |
+    <%= link_to 'Gaelic', admin_petition_details_path(@petition, locale: "gd-GB") %>
+  <% end %>
 </p>
 
 <% if @petition.rejected? or @petition.hidden? -%>

--- a/app/views/admin/petitions/_reject.html.erb
+++ b/app/views/admin/petitions/_reject.html.erb
@@ -38,16 +38,24 @@
       </div>
     </div>
 
-    <%= form_row for: [r.object, :details_en] do %>
-      <%= r.label :details_en, 'Additional details in English (optional)', class: 'form-label' %>
-      <%= error_messages_for_field r.object, :details_en %>
-      <%= r.text_area :details_en, rows: 8, cols: 70, class: 'form-control' %>
-    <% end %>
+    <% if Site.disable_gaelic_website? %>
+      <%= form_row for: [r.object, :details_en] do %>
+        <%= r.label :details_en, 'Additional details (optional)', class: 'form-label' %>
+        <%= error_messages_for_field r.object, :details_en %>
+        <%= r.text_area :details_en, rows: 8, cols: 70, class: 'form-control' %>
+      <% end %>
+    <% else %>
+      <%= form_row for: [r.object, :details_en] do %>
+        <%= r.label :details_en, 'Additional details in English (optional)', class: 'form-label' %>
+        <%= error_messages_for_field r.object, :details_en %>
+        <%= r.text_area :details_en, rows: 8, cols: 70, class: 'form-control' %>
+      <% end %>
 
-    <%= form_row for: [r.object, :details_gd] do %>
-      <%= r.label :details_gd, 'Additional details in Gaelic (optional)', class: 'form-label' %>
-      <%= error_messages_for_field r.object, :details_gd %>
-      <%= r.text_area :details_gd, rows: 8, cols: 70, class: 'form-control' %>
+      <%= form_row for: [r.object, :details_gd] do %>
+        <%= r.label :details_gd, 'Additional details in Gaelic (optional)', class: 'form-label' %>
+        <%= error_messages_for_field r.object, :details_gd %>
+        <%= r.text_area :details_gd, rows: 8, cols: 70, class: 'form-control' %>
+      <% end %>
     <% end %>
   <% end %>
 </div>

--- a/app/views/admin/rejection_reasons/_form.html.erb
+++ b/app/views/admin/rejection_reasons/_form.html.erb
@@ -11,16 +11,24 @@
   <%= form.text_field :title, tabindex: increment, maxlength: 100, class: 'form-control' %>
 <% end %>
 
-<%= form_row for: [form.object, :description_en] do %>
-  <%= form.label :description_en, "Description in English", class: 'form-label' %>
-  <%= error_messages_for_field @rejection_reason, :description_en %>
-  <%= form.text_area :description_en, tabindex: increment, rows: 6, class: 'form-control' %>
-<% end %>
+<% if Site.disable_gaelic_website? %>
+  <%= form_row for: [form.object, :description_en] do %>
+    <%= form.label :description_en, "Description", class: 'form-label' %>
+    <%= error_messages_for_field @rejection_reason, :description_en %>
+    <%= form.text_area :description_en, tabindex: increment, rows: 6, class: 'form-control' %>
+  <% end %>
+<% else %>
+  <%= form_row for: [form.object, :description_en] do %>
+    <%= form.label :description_en, "Description in English", class: 'form-label' %>
+    <%= error_messages_for_field @rejection_reason, :description_en %>
+    <%= form.text_area :description_en, tabindex: increment, rows: 6, class: 'form-control' %>
+  <% end %>
 
-<%= form_row for: [form.object, :description_gd] do %>
-  <%= form.label :description_gd, "Description in Gaelic", class: 'form-label' %>
-  <%= error_messages_for_field @rejection_reason, :description_gd %>
-  <%= form.text_area :description_gd, tabindex: increment, rows: 6, class: 'form-control' %>
+  <%= form_row for: [form.object, :description_gd] do %>
+    <%= form.label :description_gd, "Description in Gaelic", class: 'form-label' %>
+    <%= error_messages_for_field @rejection_reason, :description_gd %>
+    <%= form.text_area :description_gd, tabindex: increment, rows: 6, class: 'form-control' %>
+  <% end %>
 <% end %>
 
 <h3>Should this rejection reason hide the petition?</h3>

--- a/app/views/admin/sites/_gaelic.html.erb
+++ b/app/views/admin/sites/_gaelic.html.erb
@@ -17,3 +17,16 @@
   <%= error_messages_for_field @site, :email_from_gd %>
   <%= form.text_field :email_from_gd, tabindex: increment, maxlength: 100, class: "form-control" %>
 <% end %>
+
+<%= form_row for: [form.object, :disable_gaelic_website], class: "inline" do %>
+  <%= form.label :disable_gaelic_website, "Disable Gaelic website?", class: "form-label" %>
+  <%= error_messages_for_field @site, :disable_gaelic_website %>
+  <div class="multiple-choice">
+    <%= form.radio_button :disable_gaelic_website, true %>
+    <%= form.label :disable_gaelic_website, "Yes", for: "site_disable_gaelic_website_true" %>
+  </div>
+  <div class="multiple-choice">
+    <%= form.radio_button :disable_gaelic_website, false %>
+    <%= form.label :disable_gaelic_website, "No", for: "site_disable_gaelic_website_false" %>
+  </div>
+<% end %>

--- a/app/views/admin/topics/_form.html.erb
+++ b/app/views/admin/topics/_form.html.erb
@@ -1,7 +1,9 @@
 <div class="grid-row">
   <div class="column-half extra-gutter">
     <fieldset>
-      <legend><h2>English</h2></legend>
+      <% unless Site.disable_gaelic_website? %>
+        <legend><h2>English</h2></legend>
+      <% end %>
 
       <%= form_row for: [form.object, :code_en] do %>
         <%= form.label :code_en, "Code", class: 'form-label' %>
@@ -17,23 +19,25 @@
     </fieldset>
   </div>
 
-  <div class="column-half extra-gutter">
-    <fieldset>
-      <legend><h2>Gaelic</h2></legend>
+  <% unless Site.disable_gaelic_website? %>
+    <div class="column-half extra-gutter">
+      <fieldset>
+        <legend><h2>Gaelic</h2></legend>
 
-      <%= form_row for: [form.object, :code_gd] do %>
-        <%= form.label :code_gd, "Code", class: 'form-label' %>
-        <%= error_messages_for_field @topic, :code_gd %>
-        <%= form.text_field :code_gd, tabindex: increment, maxlength: 100, autofocus: true, class: 'form-control' %>
-      <% end %>
+        <%= form_row for: [form.object, :code_gd] do %>
+          <%= form.label :code_gd, "Code", class: 'form-label' %>
+          <%= error_messages_for_field @topic, :code_gd %>
+          <%= form.text_field :code_gd, tabindex: increment, maxlength: 100, autofocus: true, class: 'form-control' %>
+        <% end %>
 
-      <%= form_row for: [form.object, :name_gd] do %>
-        <%= form.label :name_gd, "Name", class: 'form-label' %>
-        <%= error_messages_for_field @topic, :name_gd %>
-        <%= form.text_field :name_gd, tabindex: increment, maxlength: 100, class: 'form-control' %>
-      <% end %>
-    </fieldset>
-  </div>
+        <%= form_row for: [form.object, :name_gd] do %>
+          <%= form.label :name_gd, "Name", class: 'form-label' %>
+          <%= error_messages_for_field @topic, :name_gd %>
+          <%= form.text_field :name_gd, tabindex: increment, maxlength: 100, class: 'form-control' %>
+        <% end %>
+      </fieldset>
+    </div>
+  <% end %>
 </div>
 
 <%= form.submit 'Save', class: 'button' %>

--- a/app/views/admin/topics/_topic.html.erb
+++ b/app/views/admin/topics/_topic.html.erb
@@ -1,11 +1,19 @@
 <tr>
   <td>
     <%= link_to edit_admin_topic_path(topic) do %>
-      <%= topic.code_en %> / <%= topic.code_gd %>
+      <% if Site.disable_gaelic_website? %>
+        <%= topic.code %>
+      <% else %>
+        <%= topic.code_en %> / <%= topic.code_gd %>
+      <% end %>
     <% end %>
   </td>
   <td>
-    <%= topic.name_en %> / <%= topic.name_gd %>
+    <% if Site.disable_gaelic_website? %>
+      <%= topic.name %>
+    <% else %>
+      <%= topic.name_en %> / <%= topic.name_gd %>
+    <% end %>
   </td>
   <td>
     <%= button_to 'Delete', admin_topic_path(topic, params.permit(:q)), method: :delete, class: 'button-warning', data: { confirm: 'Delete topic?' } %>

--- a/app/views/application/_header.html.erb
+++ b/app/views/application/_header.html.erb
@@ -1,6 +1,6 @@
 <header role="banner">
   <div class="wrapper">
-    <% unless request.nil? %>
+    <% if show_language_switcher? %>
       <%= language_switcher_tag %>
     <% end %>
 

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -129,3 +129,4 @@ en-GB:
       user_count_is_too_low: "There needs to be at least one admin user"
       submitted_paper_petition: "Paper petition submitted successfully"
       unable_to_submit_paper_petition: "Unable to submit paper petition - please check the form for errors"
+      unable_to_create_petition_email: "Unable to create other parliamentary business - please check the form for errors"

--- a/db/migrate/20210201162617_make_gaelic_columns_nullable.rb
+++ b/db/migrate/20210201162617_make_gaelic_columns_nullable.rb
@@ -1,0 +1,8 @@
+class MakeGaelicColumnsNullable < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :petition_emails, :subject_gd, true
+    change_column_null :rejection_reasons, :description_gd, true
+    change_column_null :topics, :code_gd, true
+    change_column_null :topics, :name_gd, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_01_27_084351) do
+ActiveRecord::Schema.define(version: 2021_02_01_162617) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -39,7 +39,7 @@ ActiveRecord::Schema.define(version: 2021_01_27_084351) do
     t.index ["last_name", "first_name"], name: "index_admin_users_on_last_name_and_first_name"
   end
 
-  create_table "constituencies", id: :string, limit: 9, force: :cascade do |t|
+  create_table "constituencies", id: { type: :string, limit: 9 }, force: :cascade do |t|
     t.string "region_id", limit: 9, null: false
     t.string "name_en", limit: 100, null: false
     t.string "name_gd", limit: 100, null: false
@@ -224,7 +224,7 @@ ActiveRecord::Schema.define(version: 2021_01_27_084351) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "subject_en", null: false
-    t.string "subject_gd", null: false
+    t.string "subject_gd"
     t.text "body_en"
     t.text "body_gd"
     t.index ["petition_id"], name: "index_petition_emails_on_petition_id"
@@ -305,7 +305,7 @@ ActiveRecord::Schema.define(version: 2021_01_27_084351) do
     t.index ["topics"], name: "index_petitions_on_topics", opclass: :gin__int_ops, using: :gin
   end
 
-  create_table "postcodes", id: :string, limit: 7, force: :cascade do |t|
+  create_table "postcodes", id: { type: :string, limit: 7 }, force: :cascade do |t|
     t.string "constituency_id", limit: 9, null: false
     t.index ["constituency_id"], name: "index_postcodes_on_constituency_id"
   end
@@ -335,7 +335,7 @@ ActiveRecord::Schema.define(version: 2021_01_27_084351) do
     t.integer "sponsor_rate", default: 5, null: false
   end
 
-  create_table "regions", id: :string, limit: 9, force: :cascade do |t|
+  create_table "regions", id: { type: :string, limit: 9 }, force: :cascade do |t|
     t.string "name_en", limit: 100, null: false
     t.string "name_gd", limit: 100, null: false
     t.datetime "created_at", null: false
@@ -348,7 +348,7 @@ ActiveRecord::Schema.define(version: 2021_01_27_084351) do
     t.string "code", limit: 30, null: false
     t.string "title", limit: 100, null: false
     t.string "description_en", limit: 2000, null: false
-    t.string "description_gd", limit: 2000, null: false
+    t.string "description_gd", limit: 2000
     t.boolean "hidden", default: false, null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -474,9 +474,9 @@ ActiveRecord::Schema.define(version: 2021_01_27_084351) do
 
   create_table "topics", force: :cascade do |t|
     t.string "code_en", limit: 100, null: false
-    t.string "code_gd", limit: 100, null: false
+    t.string "code_gd", limit: 100
     t.string "name_en", limit: 100, null: false
-    t.string "name_gd", limit: 100, null: false
+    t.string "name_gd", limit: 100
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.index ["code_en"], name: "index_topics_on_code_en", unique: true

--- a/features/admin/moderator_responds_to_petition.feature
+++ b/features/admin/moderator_responds_to_petition.feature
@@ -67,6 +67,15 @@ Feature: Moderator respond to petition
     Then the petition should be visible on the site for signing
     And the creator should receive a notification email
 
+  Scenario: Moderator publishes petition when Gaelic is disabled
+    Given I am logged in as a moderator
+    And the Gaelic website is disabled
+    When I look at the next petition on my list
+    And the petition is not translated
+    And I publish the petition
+    Then the petition should be visible on the site for signing
+    And the creator should receive a notification email
+
   Scenario: Moderator publishes petition with a custom closing date
     Given the date is the "20 April 2020"
     And I am logged in as a moderator

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -14,6 +14,10 @@ Given(/^the site is protected$/) do
   Site.instance.update! protected: true, username: "username", password: "password"
 end
 
+Given(/^the Gaelic website is disabled$/) do
+  Site.instance.update! feature_flags: { disable_gaelic_website: true }
+end
+
 Given(/^the request is not local$/) do
   page.driver.options[:headers] = { "REMOTE_ADDR" => "192.168.1.128" }
 end

--- a/features/step_definitions/moderation_steps.rb
+++ b/features/step_definitions/moderation_steps.rb
@@ -171,6 +171,24 @@ Given /^the petition is translated$/ do
   end
 end
 
+Given /^the petition is not translated$/ do
+  (@sponsored_petition || @petition).tap do |petition|
+    if petition.english?
+      petition.update!(
+        action_gd: nil,
+        background_gd: nil,
+        additional_details_gd: nil
+      )
+    else
+      petition.update!(
+        action_en: nil,
+        background_en: nil,
+        additional_details_en: nil
+      )
+    end
+  end
+end
+
 Given /^the petition "([^"]*)" is translated$/ do |action|
   (Petition.find_by!(action: action)).tap do |petition|
     if petition.english?

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -8,6 +8,12 @@ module NavigationHelpers
   def url_to(page_name)
     case page_name
 
+    when /^the English home\s?page$/
+      home_en_url
+
+    when /^the Gaelic home\s?page$/
+      home_gd_url
+
     when /^the home\s?page$/
       home_url
 

--- a/features/user_sees_static_stuff.feature
+++ b/features/user_sees_static_stuff.feature
@@ -20,3 +20,13 @@ Feature: User views static pages
     Then I should be on the privacy page
     And I should see "Privacy and cookies" in the browser page title
     And the markup should be valid
+
+  Scenario: The language switcher is disabled
+    Given the Gaelic website is disabled
+    When I go to the home page
+    Then I should not see "Gàidhlig"
+
+  Scenario: I am redirected to the English website
+    Given the Gaelic website is disabled
+    When I go to the Gaelic home page
+    Then I should be on the English home page

--- a/lib/tasks/errors.rake
+++ b/lib/tasks/errors.rake
@@ -37,6 +37,10 @@ namespace :errors do
       def holding_page?
         false
       end
+
+      def show_language_switcher?
+        false
+      end
     end
 
     lookup_context = ActionView::LookupContext.new('app/views')

--- a/spec/models/rejection_reason_spec.rb
+++ b/spec/models/rejection_reason_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe RejectionReason, type: :model do
     it { is_expected.to have_db_column(:code).of_type(:string).with_options(limit: 30, null: false) }
     it { is_expected.to have_db_column(:title).of_type(:string).with_options(limit: 100, null: false) }
     it { is_expected.to have_db_column(:description_en).of_type(:string).with_options(limit: 2000, null: false) }
-    it { is_expected.to have_db_column(:description_gd).of_type(:string).with_options(limit: 2000, null: false) }
+    it { is_expected.to have_db_column(:description_gd).of_type(:string).with_options(limit: 2000) }
     it { is_expected.to have_db_column(:hidden).of_type(:boolean).with_options(null: false, default: false) }
     it { is_expected.to have_db_column(:created_at).of_type(:datetime).with_options(null: false) }
     it { is_expected.to have_db_column(:updated_at).of_type(:datetime).with_options(null: false) }


### PR DESCRIPTION
When disabling the Gaelic website all the relevant fields in the moderation portal are hidden, the Gaelic domain redirects to the English domain and constraints on models are removed.

Option to disable is on the Gaelic website settings tab in the moderation portal

![image](https://user-images.githubusercontent.com/6321/106507770-6a509b80-64c3-11eb-97bd-63227aef30c1.png)
