### PR TITLE
Make factories (mostly) consistent

### DIFF
--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -461,10 +461,6 @@ class Signature < ActiveRecord::Base
       arel_table[Arel.star].count
     end
 
-    def max_validated_at
-      arel_table[:validated_at].maximum
-    end
-
     def normalize_email(email)
       "#{normalize_user(email)}@#{normalize_domain(email)}"
     end

--- a/features/step_definitions/admin_search_steps.rb
+++ b/features/step_definitions/admin_search_steps.rb
@@ -20,7 +20,6 @@ Given(/^a petition "(.*?)" signed by "([^"]*)"$/) do |action, name_or_email|
 
   @petition = FactoryBot.create(:open_petition, action: action)
   @signature = FactoryBot.create(:validated_signature, attrs.merge(petition: @petition))
-  @petition.update_signature_count!
 end
 
 Given(/^(\d+) petitions? signed from "([^"]*)"$/) do |petition_count, ip_address|

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -14,14 +14,8 @@ When(/^I navigate to the next page of petitions$/) do
   click_link "Next"
 end
 
-Given(/^a(n)? ?(pending|validated|sponsored|flagged|open|rejected)? petition "([^"]*)"$/) do |a_or_an, state, petition_action|
-  petition_args = {
-    :action => petition_action,
-    :closed_at => 1.day.from_now,
-    :state => state || "open"
-  }
-  @petition = FactoryBot.create(:open_petition, petition_args)
-  @petition.update_signature_count!
+Given(/^an? ?(pending|validated|sponsored|flagged|open|rejected)? petition "([^"]*)"$/) do |state, action|
+  @petition = FactoryBot.create(:"#{state || 'open'}_petition", action: action)
 end
 
 Given(/^a (sponsored|flagged) petition "(.*?)" reached threshold (\d+) days? ago$/) do |state, action, age|
@@ -352,7 +346,6 @@ Given(/^an? (open|closed|rejected) petition "(.*?)" with some (fraudulent)? ?sig
   @petition = FactoryBot.create(:"#{state}_petition", petition_args)
   signature_state ||= "validated"
   5.times { FactoryBot.create(:"#{signature_state}_signature", petition: @petition) }
-  @petition.update_signature_count!
 end
 
 Given(/^the threshold for a Parliament debate is "(.*?)"$/) do |amount|

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -168,23 +168,27 @@ And "I have already signed the petition but not validated my email" do
 end
 
 And "I have already signed the petition using an alias" do
-  FactoryBot.create(:signature, name: "Womboid Wibbledon", :petition => @petition,
-                     :email => "wom.boid@wimbledon.com", :postcode => "G340BX")
+  FactoryBot.create(:validated_signature, petition: @petition,
+    name: "Womboid Wibbledon",  email: "wom.boid@wimbledon.com", postcode: "G340BX"
+  )
 end
 
 And "I have already signed the petition using an alias but not validated my email" do
-  FactoryBot.create(:pending_signature, name: "Womboid Wibbledon", :petition => @petition,
-                     :email => "wom.boid@wimbledon.com", :postcode => "G340BX")
+  FactoryBot.create(:pending_signature, petition: @petition,
+    name: "Womboid Wibbledon",  email: "wom.boid@wimbledon.com", postcode: "G340BX"
+  )
 end
 
 Given /^Suzie has already signed the petition$/ do
-  @suzies_signature = FactoryBot.create(:signature, :petition => @petition, :email => "womboid@wimbledon.com",
-         :postcode => "G34 0BX", :name => "Womboid Wibbledon")
+  @suzies_signature = FactoryBot.create(:validated_signature, petition: @petition,
+    name: "Womboid Wibbledon",  email: "womboid@wimbledon.com", postcode: "G340BX"
+  )
 end
 
 Given /^Eric has already signed the petition with Suzies email$/ do
-  FactoryBot.create(:signature, :petition => @petition, :email => "womboid@wimbledon.com",
-         :postcode => "G34 0BX", :name => "Eric Wibbledon")
+  FactoryBot.create(:validated_signature, petition: @petition,
+    name: "Eric Wibbledon",  email: "womboid@wimbledon.com", postcode: "G340BX"
+  )
 end
 
 Given(/^"([^"]*)" is configured to normalize email address$/) do |domain|
@@ -192,13 +196,9 @@ Given(/^"([^"]*)" is configured to normalize email address$/) do |domain|
 end
 
 Given /^I have signed the petition with a second name$/ do
-  FactoryBot.create(:signature, :petition => @petition, :email => "womboid@wimbledon.com",
-         :postcode => "G34 0BX", :name => "Sam Wibbledon")
-end
-
-Given(/^Suzie has already signed the petition and validated her email$/) do
-  @suzies_signature = FactoryBot.create(:validated_signature, :petition => @petition, :email => "womboid@wimbledon.com",
-         :postcode => "G34 0BX", :name => "Womboid Wibbledon")
+  FactoryBot.create(:validated_signature, petition: @petition,
+    name: "Sam Wibbledon",  email: "womboid@wimbledon.com", postcode: "G340BX"
+  )
 end
 
 When(/^Suzie shares the signatory confirmation link with Eric$/) do

--- a/features/suzie_signs_a_petition.feature
+++ b/features/suzie_signs_a_petition.feature
@@ -155,7 +155,7 @@ Feature: Suzie signs a petition
     And I can click on a link to return to the petition
 
   Scenario: Eric clicks the link shared to him by Suzie
-    When Suzie has already signed the petition and validated her email
+    When Suzie has already signed the petition
     And Suzie shares the signatory confirmation link with Eric
     And I click the shared link
     Then I should see "Sign this petition"

--- a/spec/jobs/petition_count_job_spec.rb
+++ b/spec/jobs/petition_count_job_spec.rb
@@ -26,12 +26,6 @@ RSpec.describe PetitionCountJob, type: :job do
       )
     end
 
-    before do
-      # FIXME: reset the signature count to ensure it's valid because
-      # the factories don't leave the petition in a consistent state.
-      petition.update_signature_count!(60.seconds.ago)
-    end
-
     it "doesn't enqueue a ResetPetitionSignatureCountJob job" do
       expect {
         described_class.perform_now

--- a/spec/jobs/update_signature_counts_job_spec.rb
+++ b/spec/jobs/update_signature_counts_job_spec.rb
@@ -58,8 +58,7 @@ RSpec.describe UpdateSignatureCountsJob, type: :job do
       let(:constituency_journal) { ConstituencyPetitionJournal.for(petition, "9999") }
 
       before do
-        # FIXME: reset the signature count to ensure it's valid because
-        # the factories don't leave the petition in a consistent state.
+        # Rewind the petition to the previous count state
         petition.update_signature_count!(previous_count_updated_at)
       end
 

--- a/spec/models/constituency_petition_journal_spec.rb
+++ b/spec/models/constituency_petition_journal_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
     let(:signature_count) { 1 }
 
     context "when the supplied signature is valid" do
-      let(:signature) { FactoryBot.build(:invalidated_signature, petition: petition, constituency_id: constituency_id) }
+      let(:signature) { FactoryBot.create(:validated_signature, petition: petition, constituency_id: constituency_id) }
       let(:now) { 1.hour.from_now.change(usec: 0) }
 
       it "decrements the signature_count by 1" do
@@ -141,7 +141,7 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
     end
 
     context "when no journal exists" do
-      let(:signature) { FactoryBot.build(:invalidated_signature, petition: petition, constituency_id: constituency_id) }
+      let(:signature) { FactoryBot.create(:validated_signature, petition: petition, constituency_id: constituency_id) }
 
       before do
         described_class.delete_all
@@ -158,7 +158,7 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
   describe ".increment_signature_counts_for" do
     let(:constituency_1) { FactoryBot.generate(:constituency_id) }
     let(:constituency_2) { FactoryBot.generate(:constituency_id) }
-    let!(:petition) { FactoryBot.create(:petition, creator_attributes: { constituency_id: constituency_1 }) }
+    let!(:petition) { FactoryBot.create(:open_petition, creator_attributes: { constituency_id: constituency_1 }) }
 
     let(:journal_1) { described_class.for(petition, constituency_1) }
     let(:journal_2) { described_class.for(petition, constituency_2) }
@@ -167,7 +167,6 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
       FactoryBot.create(:validated_signature, petition: petition, constituency_id: constituency_1)
       FactoryBot.create(:validated_signature, petition: petition, constituency_id: constituency_2)
 
-      petition.update_signature_count!
       described_class.reset_signature_counts_for(petition)
     end
 
@@ -175,8 +174,8 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
       expect(journal_1.signature_count).to eq(2)
       expect(journal_2.signature_count).to eq(1)
 
-      FactoryBot.create(:validated_signature, petition: petition, constituency_id: constituency_1)
-      FactoryBot.create(:validated_signature, petition: petition, constituency_id: constituency_2)
+      FactoryBot.create(:validated_signature, petition: petition, constituency_id: constituency_1, increment: false)
+      FactoryBot.create(:validated_signature, petition: petition, constituency_id: constituency_2, increment: false)
 
       last_signed_at = petition.last_signed_at
       petition.increment_signature_count!
@@ -189,16 +188,12 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
   end
 
   describe ".reset_signature_counts_for" do
-    let(:petition_1) { FactoryBot.create(:petition, creator_attributes: {constituency_id: constituency_1, validated_at: 5.minutes.ago}) }
+    let(:petition_1) { FactoryBot.create(:open_petition, creator_attributes: { constituency_id: constituency_1, validated_at: 5.minutes.ago }) }
     let(:constituency_1) { FactoryBot.generate(:constituency_id) }
-    let(:petition_2) { FactoryBot.create(:petition, creator_attributes: {constituency_id: constituency_1, validated_at: 5.minutes.ago}) }
+    let(:petition_2) { FactoryBot.create(:open_petition, creator_attributes: { constituency_id: constituency_1, validated_at: 5.minutes.ago }) }
     let(:constituency_2) { FactoryBot.generate(:constituency_id) }
 
     before do
-      # We do this so last_signed_at is not nil
-      petition_1.update_signature_count!
-      petition_2.update_signature_count!
-
       described_class.for(petition_1, constituency_1).update_columns(signature_count: 20, last_signed_at: 5.minutes.ago)
       described_class.for(petition_1, constituency_2).update_columns(signature_count: 10, last_signed_at: nil)
       described_class.for(petition_2, constituency_1).update_columns(signature_count: 1, last_signed_at: 5.minutes.ago)

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1550,7 +1550,7 @@ RSpec.describe Petition, type: :model do
 
     context "when there is one more signature" do
       before do
-        FactoryBot.create(:validated_signature, petition: petition)
+        FactoryBot.create(:validated_signature, petition: petition, increment: false)
       end
 
       it "increases the signature count by 1" do
@@ -1573,7 +1573,7 @@ RSpec.describe Petition, type: :model do
     context "when there is more than one signature" do
       before do
         5.times do
-          FactoryBot.create(:validated_signature, petition: petition)
+          FactoryBot.create(:validated_signature, petition: petition, increment: false)
         end
       end
 
@@ -1600,8 +1600,13 @@ RSpec.describe Petition, type: :model do
           state: "pending",
           signature_count: 0,
           last_signed_at: nil,
-          updated_at: 2.days.ago
+          updated_at: 2.days.ago,
+          increment: false
         })
+      end
+
+      before do
+        FactoryBot.create(:validated_signature, petition: petition, sponsor: true, increment: false)
       end
 
       it "records changes the state from 'pending' to 'validated'" do
@@ -1618,7 +1623,7 @@ RSpec.describe Petition, type: :model do
 
       before do
         expect(Site).to receive(:threshold_for_referral).and_return(5)
-        FactoryBot.create(:validated_signature, petition: petition)
+        FactoryBot.create(:validated_signature, petition: petition, increment: false)
       end
 
       context "having already been validated by a sponsor" do
@@ -1678,7 +1683,7 @@ RSpec.describe Petition, type: :model do
       let(:signature_count) { 100 }
 
       before do
-        FactoryBot.create(:validated_signature, petition: petition)
+        FactoryBot.create(:validated_signature, petition: petition, increment: false)
       end
 
       context "and moderation_threshold_reached_at is nil" do
@@ -1710,7 +1715,7 @@ RSpec.describe Petition, type: :model do
 
       before do
         expect(Site).to receive(:threshold_for_referral).and_return(10)
-        FactoryBot.create(:validated_signature, petition: petition)
+        FactoryBot.create(:validated_signature, petition: petition, increment: false)
       end
 
       it "records the time it happened" do
@@ -1727,7 +1732,7 @@ RSpec.describe Petition, type: :model do
 
       before do
         expect(Site).to receive(:threshold_for_debate).and_return(100)
-        FactoryBot.create(:validated_signature, petition: petition)
+        FactoryBot.create(:validated_signature, petition: petition, increment: false)
       end
 
       it "records the time it happened" do
@@ -1851,7 +1856,7 @@ RSpec.describe Petition, type: :model do
       let(:petition) { FactoryBot.create(:sponsored_petition) }
 
       before do
-        expect(Site).not_to receive(:threshold_for_referral)
+        expect(Site).not_to receive(:threshold_for_moderation)
       end
 
       it "is falsey" do
@@ -1897,7 +1902,7 @@ RSpec.describe Petition, type: :model do
       let(:petition) { FactoryBot.create(:sponsored_petition) }
 
       before do
-        expect(Site).not_to receive(:threshold_for_referral)
+        expect(Site).not_to receive(:threshold_for_moderation)
       end
 
       it "is falsey" do
@@ -2391,7 +2396,7 @@ RSpec.describe Petition, type: :model do
   end
 
   describe "#signatures_to_email_for" do
-    let!(:petition) { FactoryBot.create(:petition) }
+    let!(:petition) { FactoryBot.create(:open_petition) }
     let!(:creator) { petition.creator }
     let!(:other_signature) { FactoryBot.create(:validated_signature, petition: petition) }
     let(:petition_timestamp) { 5.days.ago }

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -331,12 +331,12 @@ RSpec.describe Signature, type: :model do
   describe "scopes" do
     let(:week_ago) { 1.week.ago }
     let(:two_days_ago) { 2.days.ago }
-    let!(:petition) { FactoryBot.create(:petition) }
-    let!(:signature1) { FactoryBot.create(:signature, :email => "person1@example.com", :petition => petition, :state => Signature::VALIDATED_STATE, :notify_by_email => true) }
-    let!(:signature2) { FactoryBot.create(:signature, :email => "person2@example.com", :petition => petition, :state => Signature::PENDING_STATE, :notify_by_email => true) }
-    let!(:signature3) { FactoryBot.create(:signature, :email => "person3@example.com", :petition => petition, :state => Signature::VALIDATED_STATE, :notify_by_email => false) }
-    let!(:signature4) { FactoryBot.create(:signature, :email => "person4@example.com", :petition => petition, :state => Signature::INVALIDATED_STATE, :notify_by_email => false) }
-    let!(:signature5) { FactoryBot.create(:signature, :email => "person4@example.com", :petition => petition, :state => Signature::FRAUDULENT_STATE, :notify_by_email => false) }
+    let!(:petition) { FactoryBot.create(:open_petition) }
+    let!(:signature1) { FactoryBot.create(:validated_signature, email: "person1@example.com", petition: petition, notify_by_email: true) }
+    let!(:signature2) { FactoryBot.create(:pending_signature, email: "person2@example.com", petition: petition, notify_by_email: true) }
+    let!(:signature3) { FactoryBot.create(:validated_signature, email: "person3@example.com", petition: petition, notify_by_email: false) }
+    let!(:signature4) { FactoryBot.create(:invalidated_signature, email: "person4@example.com", petition: petition, notify_by_email: false) }
+    let!(:signature5) { FactoryBot.create(:fraudulent_signature, email: "person4@example.com", petition: petition, notify_by_email: false) }
 
     describe "validated" do
       it "returns only validated signatures" do


### PR DESCRIPTION
In a number of places we are doing hacky things to ensure petitions are in a consistent state for the tests we're doing. This commit removes most of those aside from instances where we're checking things like signature counting jobs, invalidation, etc.

This also picked up a few places where the test setup was incorrect.