### PR TITLE
Add pp and pe numbers

### DIFF
--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -85,7 +85,7 @@ class PetitionsController < LocalizedController
   protected
 
   def petition_id
-    Integer(params[:id])
+    params[:id]
   rescue ArgumentError => e
     raise ActionController::BadRequest, "Invalid petition id: #{params[:id]}"
   end

--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -9,6 +9,7 @@ class PetitionsController < LocalizedController
   before_action :retrieve_petition, only: [:show, :count, :gathering_support, :moderation_info]
   before_action :build_petition_creator, only: [:check, :check_results, :new, :create]
 
+  before_action :raise_not_found, unless: :site_collecting_sponsors?, only: %i[gathering_support moderation_info]
   before_action :redirect_to_gathering_support_url, if: :collecting_sponsors?, only: [:moderation_info, :show]
   before_action :redirect_to_moderation_info_url, if: :in_moderation?, only: [:gathering_support, :show]
   before_action :redirect_to_petition_url, if: :moderated?, only: [:gathering_support, :moderation_info]
@@ -168,5 +169,13 @@ class PetitionsController < LocalizedController
 
   def set_content_disposition
     response.headers['Content-Disposition'] = "attachment; filename=#{csv_filename}"
+  end
+
+  def raise_not_found
+    raise ActiveRecord::RecordNotFound, "Unable to find petition"
+  end
+
+  def site_collecting_sponsors?
+    Site.collecting_sponsors?
   end
 end

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -80,7 +80,7 @@ class SignaturesController < LocalizedController
   private
 
   def petition_id
-    @petition_id ||= Integer(params[:petition_id])
+    @petition_id ||= params[:petition_id]
   rescue ArgumentError => e
     raise ActionController::BadRequest, "Invalid petition id: #{params[:petition_id]}"
   end

--- a/app/helpers/home_helper.rb
+++ b/app/helpers/home_helper.rb
@@ -74,7 +74,7 @@ module HomeHelper
     Rails.cache.fetch([:trending_petitions, I18n.locale, now.to_i], expires_in: 5.minutes) do
       signature_id = Signature.arel_table[:id]
       signature_count = signature_id.count.as("signature_count_in_period")
-      Petition.trending(period.ago(now)..now).pluck(:id, :action, signature_count)
+      Petition.trending(period.ago(now)..now).pluck(:pe_number_id, :action, signature_count)
     end
   end
   private :fetch_trending_petitions

--- a/app/models/paper_petition.rb
+++ b/app/models/paper_petition.rb
@@ -134,6 +134,8 @@ class PaperPetition
     @signature = @petition.build_creator(signature_params)
     @contact = @signature.build_contact(contact_params)
 
+    @petition.build_pe_number
+
     @petition.save!
   end
 

--- a/app/models/pe_number.rb
+++ b/app/models/pe_number.rb
@@ -1,0 +1,2 @@
+class PeNumber < ActiveRecord::Base
+end

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -76,6 +76,7 @@ class Petition < ActiveRecord::Base
   accepts_nested_attributes_for :creator, update_only: true
 
   belongs_to :locked_by, class_name: 'AdminUser', optional: true
+  belongs_to :pe_number, optional: true
 
   has_one :debate_outcome, dependent: :destroy
   has_one :email_requested_receipt, dependent: :destroy

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -495,7 +495,7 @@ class Petition < ActiveRecord::Base
   end
 
   def to_param
-    published? ? ('PE%05d' % pe_number_id) : ('PP%05d' % id)
+    published? ? ('PE%04d' % pe_number_id) : ('PP%04d' % id)
   end
 
   def statistics

--- a/app/presenters/petition_csv_presenter.rb
+++ b/app/presenters/petition_csv_presenter.rb
@@ -46,11 +46,11 @@ class PetitionCSVPresenter
   end
 
   def public_url
-    petition_url id
+    petition_url @petition
   end
 
   def admin_url
-    admin_petition_url id
+    admin_petition_url @petition
   end
 
   def notes

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -65,11 +65,11 @@
   <dd><%= link_to petition_path(@petition), petition_url(@petition), target: "_blank" %></dd>
 
   <dt>PP Number</dt>
-  <dd><%= ('PP%05d' % @petition.id) %></dd>
+  <dd><%= ('PP%04d' % @petition.id) %></dd>
 
   <% unless @petition.pe_number_id.nil? %>
     <dt>PE Number</dt>
-    <dd><%= ('PE%05d' % @petition.pe_number_id) %></dd>
+    <dd><%= ('PE%04d' % @petition.pe_number_id) %></dd>
   <% end %>
 
   <% if @petition.tags? %>

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -64,8 +64,13 @@
   <dt>Link to petition</dt>
   <dd><%= link_to petition_path(@petition), petition_url(@petition), target: "_blank" %></dd>
 
-  <dt>ID</dt>
-  <dd><%= @petition.id %></dd>
+  <dt>PP Number</dt>
+  <dd><%= ('PP%05d' % @petition.id) %></dd>
+
+  <% unless @petition.pe_number_id.nil? %>
+    <dt>PE Number</dt>
+    <dd><%= ('PE%05d' % @petition.pe_number_id) %></dd>
+  <% end %>
 
   <% if @petition.tags? %>
     <dt>Tags</dt>

--- a/app/views/admin/petitions/index.html.erb
+++ b/app/views/admin/petitions/index.html.erb
@@ -55,7 +55,7 @@
     <tr>
       <th class="action">Action</th>
       <th class="creator">Creator</th>
-      <th class="petition-id">ID</th>
+      <th class="petition-id">PP Number</th>
       <th class="state">State</th>
       <% if show_tags_column?(@petitions.scope) %>
         <th class="tags">Tags</th>
@@ -76,7 +76,7 @@
             –
           <% end %>
         </td>
-        <td class="petition-id"><%= petition.id %></td>
+        <td class="petition-id"><%= petition.to_param %></td>
         <td class="state"><%= petition.state.humanize %></td>
         <% if show_tags_column?(@petitions.scope) %>
           <td class="tags"><%= tag_names(petition.tags).presence || "—" %></td>

--- a/app/views/pages/home/_trending_petitions.html.erb
+++ b/app/views/pages/home/_trending_petitions.html.erb
@@ -4,7 +4,7 @@
     <ul>
       <% petitions.each do |pe_number_id, action, signature_count| %>
         <li class="petition-item">
-          <h3><%= link_to truncate(action, length: 100), petition_path(('PE%05d' % pe_number_id)) %></h3>
+          <h3><%= link_to truncate(action, length: 100), petition_path(('PE%04d' % pe_number_id)) %></h3>
           <p><%= signature_count(:trending, signature_count) %></p>
         </li>
       <% end %>

--- a/app/views/pages/home/_trending_petitions.html.erb
+++ b/app/views/pages/home/_trending_petitions.html.erb
@@ -2,9 +2,9 @@
   <section class="trending" aria-labelledby="trending-heading">
     <h2 id="trending-heading"><%= t(:"ui.home_page.trending_petitions.heading") %></h2>
     <ul>
-      <% petitions.each do |id, action, signature_count| %>
+      <% petitions.each do |pe_number_id, action, signature_count| %>
         <li class="petition-item">
-          <h3><%= link_to truncate(action, length: 100), petition_path(id) %></h3>
+          <h3><%= link_to truncate(action, length: 100), petition_path(('PE%05d' % pe_number_id)) %></h3>
           <p><%= signature_count(:trending, signature_count) %></p>
         </li>
       <% end %>

--- a/app/views/petitions/_closed_petition_show.html.erb
+++ b/app/views/petitions/_closed_petition_show.html.erb
@@ -1,9 +1,9 @@
 <%= cache_for :petition do %>
   <h1>
     <% if @petition.completed? %>
-      <span class="heading-secondary"><%= t(:"ui.petitions.heading_completed") %></span>
+      <span class="heading-secondary"><%= t(:"ui.petitions.heading_completed") %> - <%= @petition.to_param %></span>
     <% else %>
-      <span class="heading-secondary"><%= t(:"ui.petitions.heading_closed") %></span>
+      <span class="heading-secondary"><%= t(:"ui.petitions.heading_closed") %> - <%= @petition.to_param %></span>
     <% end %>
     <%= petition.action %>
   </h1>

--- a/app/views/petitions/_open_petition_show.html.erb
+++ b/app/views/petitions/_open_petition_show.html.erb
@@ -4,7 +4,7 @@
 
 <%= cache_for :petition do %>
   <h1>
-    <span class="heading-secondary"><%= t(:"ui.petitions.heading_open") %></span>
+    <span class="heading-secondary"><%= t(:"ui.petitions.heading_open")%> - <%= @petition.to_param %></span>
     <%= petition.action %>
   </h1>
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,20 +44,22 @@ Rails.application.routes.draw do
       post '/new',           action: 'create',        as: :create_petition
       get  '/thank-you',     action: 'thank_you',     as: :thank_you_petitions
 
-      scope '/:id' do
+      scope '/:id', constraints: { id: /(PE|PP)\d{1,11}/ } do
         get '/count',             action: 'count',             as: :count_petition
         get '/gathering-support', action: 'gathering_support', as: :gathering_support_petition
         get '/moderation-info',   action: 'moderation_info',   as: :moderation_info_petition
       end
 
-      scope '/:petition_id' do
+      scope '/:petition_id', constraints: { id: /PP\d{1,11}/ } do
         scope '/sponsors', controller: 'sponsors' do
           post '/new',       action: 'confirm',   as: :confirm_petition_sponsors
           get  '/thank-you', action: 'thank_you', as: :thank_you_petition_sponsors
           post '/',          action: 'create',    as: :petition_sponsors
           get  '/new',       action: 'new',       as: :new_petition_sponsor
         end
+      end
 
+      scope '/:petition_id', constraints: { id: /PE\d{1,11}/ } do
         scope '/signatures', controller: 'signatures' do
           post '/new',       action: 'confirm',   as: :confirm_petition_signatures
           get  '/thank-you', action: 'thank_you', as: :thank_you_petition_signatures
@@ -68,7 +70,7 @@ Rails.application.routes.draw do
 
       get '/',    action: 'index', as: :petitions
       get '/new', action: 'new',   as: :new_petition
-      get '/:id', action: 'show',  as: :petition
+      get '/:id', action: 'show',  as: :petition, constraints: { id: /(PE|PP)\d{1,11}/ }
     end
 
     scope '/petitioners', controller: 'petitioners' do
@@ -124,7 +126,7 @@ Rails.application.routes.draw do
 
       resources :paper_petitions, only: %i[new create]
 
-      resources :petitions, only: %i[show index] do
+      resources :petitions, only: %i[show index], constraints: { id: /(PE|PP)?\d{1,11}/ } do
         post :resend, on: :member
 
         resources :emails, controller: 'petition_emails', except: %i[show]

--- a/db/migrate/20210203114826_create_pe_number_and_foreign_key.rb
+++ b/db/migrate/20210203114826_create_pe_number_and_foreign_key.rb
@@ -1,0 +1,8 @@
+class CreatePeNumberAndForeignKey < ActiveRecord::Migration[6.1]
+  def change
+    create_table :pe_numbers do |t|
+    end
+
+    add_reference :petitions, :pe_number, index: true, default: nil, unique: true, foreign_key: { on_delete: :cascade }
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_02_01_162617) do
+ActiveRecord::Schema.define(version: 2021_02_03_114826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -218,6 +218,9 @@ ActiveRecord::Schema.define(version: 2021_02_01_162617) do
     t.index ["petition_id"], name: "index_notes_on_petition_id", unique: true
   end
 
+  create_table "pe_numbers", force: :cascade do |t|
+  end
+
   create_table "petition_emails", force: :cascade do |t|
     t.bigint "petition_id"
     t.string "sent_by"
@@ -283,6 +286,7 @@ ActiveRecord::Schema.define(version: 2021_02_01_162617) do
     t.datetime "anonymized_at"
     t.integer "topics", default: [], null: false, array: true
     t.boolean "collect_signatures", default: false, null: false
+    t.bigint "pe_number_id"
     t.index "((last_signed_at > signature_count_validated_at))", name: "index_petitions_on_validated_at_and_signed_at"
     t.index "to_tsvector('english'::regconfig, (action_en)::text)", name: "index_petitions_on_action_en", using: :gin
     t.index "to_tsvector('english'::regconfig, (background_en)::text)", name: "index_petitions_on_background_en", using: :gin
@@ -298,6 +302,7 @@ ActiveRecord::Schema.define(version: 2021_02_01_162617) do
     t.index ["last_signed_at"], name: "index_petitions_on_last_signed_at"
     t.index ["locked_by_id"], name: "index_petitions_on_locked_by_id"
     t.index ["moderation_threshold_reached_at", "moderation_lag"], name: "index_petitions_on_mt_reached_at_and_moderation_lag"
+    t.index ["pe_number_id"], name: "index_petitions_on_pe_number_id"
     t.index ["referral_threshold_reached_at"], name: "index_petitions_on_referral_threshold_reached_at"
     t.index ["referred_at", "created_at"], name: "index_petitions_on_referred_at_and_created_at", order: { created_at: :desc }
     t.index ["signature_count", "state"], name: "index_petitions_on_signature_count_and_state"
@@ -520,6 +525,7 @@ ActiveRecord::Schema.define(version: 2021_02_01_162617) do
   add_foreign_key "notes", "petitions", on_delete: :cascade
   add_foreign_key "petition_emails", "petitions", on_delete: :cascade
   add_foreign_key "petition_statistics", "petitions"
+  add_foreign_key "petitions", "pe_numbers", on_delete: :cascade
   add_foreign_key "rejections", "petitions", on_delete: :cascade
   add_foreign_key "rejections", "rejection_reasons", column: "code", primary_key: "code"
   add_foreign_key "signatures", "petitions", on_delete: :cascade

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -183,7 +183,7 @@ Then(/^I should see my search query already filled in as the action of the petit
 end
 
 Then(/^I can click on a link to return to the petition$/) do
-  slug = ('PE%05d' % @petition.pe_number_id)
+  slug = ('PE%04d' % @petition.pe_number_id)
   expect(page).to have_css("a[href*='/petitions/#{slug}']")
 end
 

--- a/features/step_definitions/petition_steps.rb
+++ b/features/step_definitions/petition_steps.rb
@@ -183,7 +183,8 @@ Then(/^I should see my search query already filled in as the action of the petit
 end
 
 Then(/^I can click on a link to return to the petition$/) do
-  expect(page).to have_css("a[href*='/petitions/#{@petition.id}']")
+  slug = ('PE%05d' % @petition.pe_number_id)
+  expect(page).to have_css("a[href*='/petitions/#{slug}']")
 end
 
 Then(/^I should receive an email telling me how to get an MP on board$/) do

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -160,11 +160,11 @@ Then(/^(I|they|".*?") should be emailed a link for gathering support from sponso
 
   if I18n.locale == :"gd-GB"
     steps %{
-      Then they should see /\/athchuingean\/\\d+\/luchd-taic\/[A-Za-z0-9]+/ in the email body
+      Then they should see /\/athchuingean\/PP\\d+\/luchd-taic\/[A-Za-z0-9]+/ in the email body
     }
   else
     steps %{
-      Then they should see /\/petitions\/\\d+\/sponsors\/[A-Za-z0-9]+/ in the email body
+      Then they should see /\/petitions\/PP\\d+\/sponsors\/[A-Za-z0-9]+/ in the email body
     }
   end
 end

--- a/features/support/paths.rb
+++ b/features/support/paths.rb
@@ -39,13 +39,13 @@ module NavigationHelpers
       new_petition_url
 
     when /^the petition page$/
-      petition_url(@petition.id)
+      petition_url(@petition)
 
     when /^the petition page for "([^\"]*)"$/
       petition_url(Petition.find_by(action: $1))
 
     when /^the new signature page$/
-      new_petition_signature_url(@petition.id)
+      new_petition_signature_url(@petition)
 
     when /^the new signature page for "([^\"]*)"$/
       new_petition_signature_url(Petition.find_by(action: $1))

--- a/spec/controllers/admin/abms_link_controller_spec.rb
+++ b/spec/controllers/admin/abms_link_controller_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe Admin::AbmsLinkController, type: :controller, admin: true do
       end
 
       it "redirects to the petition show page" do
-        expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}"
+        expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}"
       end
 
       it "sets the flash notice message" do

--- a/spec/controllers/admin/archive_controller_spec.rb
+++ b/spec/controllers/admin/archive_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Admin::ArchiveController, type: :controller, admin: true do
 
       it "redirects to the petition page" do
         patch :update, params: { petition_id: petition.id }
-        expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+        expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
       end
 
       it "displays a notice" do
@@ -62,7 +62,7 @@ RSpec.describe Admin::ArchiveController, type: :controller, admin: true do
 
         it "redirects to the petition page" do
           patch :update, params: { petition_id: petition.id }
-          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
         end
 
         it "displays an alert" do

--- a/spec/controllers/admin/completion_controller_spec.rb
+++ b/spec/controllers/admin/completion_controller_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe Admin::CompletionController, type: :controller, admin: true do
 
       it "redirects to the petition page" do
         patch :update, params: { petition_id: petition.id }
-        expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+        expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
       end
 
       it "displays a notice" do
@@ -62,7 +62,7 @@ RSpec.describe Admin::CompletionController, type: :controller, admin: true do
 
         it "redirects to the petition page" do
           patch :update, params: { petition_id: petition.id }
-          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
         end
 
         it "displays an alert" do

--- a/spec/controllers/admin/completion_date_controller_spec.rb
+++ b/spec/controllers/admin/completion_date_controller_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe Admin::CompletionDateController, type: :controller, admin: true d
 
       it "redirects to the petition page" do
         patch :update, params: { petition_id: petition.id, petition: params }
-        expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+        expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
       end
 
       it "displays a notice" do

--- a/spec/controllers/admin/debate_outcomes_controller_spec.rb
+++ b/spec/controllers/admin/debate_outcomes_controller_spec.rb
@@ -143,7 +143,7 @@ RSpec.describe Admin::DebateOutcomesController, type: :controller, admin: true d
           describe 'with valid params' do
             it 'redirects to the petition show page' do
               do_patch
-              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}"
+              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}"
             end
 
             it 'tells the moderator that their email will be sent overnight' do
@@ -355,7 +355,7 @@ RSpec.describe Admin::DebateOutcomesController, type: :controller, admin: true d
           describe 'with valid params' do
             it 'redirects to the petition show page' do
               do_patch
-              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}"
+              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}"
             end
 
             it 'tells the moderator that their changes were saved' do
@@ -492,6 +492,9 @@ RSpec.describe Admin::DebateOutcomesController, type: :controller, admin: true d
         before do
           debateable = double(:scope)
           allow(Petition).to receive(:debateable).and_return(debateable)
+          allow(Petition).to receive(:find).with(petition.pe_number_id.to_s).and_return(petition)
+          allow(Petition).to receive(:find).with(petition.id.to_s).and_return(petition)
+          allow(debateable).to receive(:find).with(petition.pe_number_id.to_s).and_return(petition)
           allow(debateable).to receive(:find).with(petition.id.to_s).and_return(petition)
         end
 

--- a/spec/controllers/admin/moderation_controller_spec.rb
+++ b/spec/controllers/admin/moderation_controller_spec.rb
@@ -64,8 +64,12 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
           expect(petition.moderation_lag).to eq(4)
         end
 
+        it "assigns a PE Number" do
+          expect(petition.pe_number_id).not_to eq(nil)
+        end
+
         it "redirects to the admin show page for the petition page" do
-          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
         end
 
         it "sends an email to the petition creator" do
@@ -124,13 +128,17 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
             expect(petition.rejection.code).to eq(rejection_code)
           end
 
+          it "does not assign a PE Number" do
+            expect(petition.pe_number_id).to eq(nil)
+          end
+
           it 'sets the rejection details to the supplied details' do
             expect(petition.rejection.details_en).to eq('rejection details')
             expect(petition.rejection.details_gd).to eq('manylion gwrthod')
           end
 
           it 'redirects to the admin show page for the petition' do
-            expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+            expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
           end
 
           it "sends an email to the petition creator" do
@@ -173,8 +181,12 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
             expect(petition.rejection.code).to eq(rejection_code)
           end
 
+          it "does not assign a PE Number" do
+            expect(petition.pe_number_id).to eq(nil)
+          end
+
           it 'redirects to the admin show page for the petition' do
-            expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+            expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
           end
 
           it "sends an email to the petition creator" do
@@ -243,8 +255,12 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
           expect(petition.moderation_lag).to be_nil
         end
 
+        it "does not assign a PE Number" do
+          expect(petition.pe_number_id).to eq(nil)
+        end
+
         it "redirects to the admin show page for the petition page" do
-          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
         end
 
         it "does not send an email to the petition creator" do
@@ -276,8 +292,12 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
           expect(petition.moderation_lag).to be_nil
         end
 
+        it "does not assign a PE Number" do
+          expect(petition.pe_number_id).to eq(nil)
+        end
+
         it "redirects to the admin show page for the petition page" do
-          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
         end
 
         it "does not send an email to the petition creator" do

--- a/spec/controllers/admin/notes_controller_spec.rb
+++ b/spec/controllers/admin/notes_controller_spec.rb
@@ -108,7 +108,7 @@ RSpec.describe Admin::NotesController, type: :controller, admin: true do
         context 'with valid params' do
           it 'redirects to the petition show page' do
             do_patch
-            expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}"
+            expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}"
           end
 
           it 'stores the supplied notes in the db' do
@@ -120,7 +120,23 @@ RSpec.describe Admin::NotesController, type: :controller, admin: true do
       end
 
       describe 'for an open petition' do
-        it_behaves_like 'updating notes for a petition'
+        it 'fetches the requested petition' do
+          do_patch
+          expect(assigns(:petition)).to eq petition
+        end
+
+        context 'with valid params' do
+          it 'redirects to the petition show page' do
+            do_patch
+            expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}"
+          end
+
+          it 'stores the supplied notes in the db' do
+            do_patch
+            petition.reload
+            expect(petition.note.details).to eq notes_attributes[:details]
+          end
+        end
       end
 
       describe 'for a pending petition' do

--- a/spec/controllers/admin/petition_details_controller_spec.rb
+++ b/spec/controllers/admin/petition_details_controller_spec.rb
@@ -129,7 +129,7 @@ RSpec.describe Admin::PetitionDetailsController, type: :controller, admin: true 
           it 'redirects to the edit petition page' do
             do_update
             petition.reload
-            expect(response).to redirect_to"https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}"
+            expect(response).to redirect_to"https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}"
           end
 
           it 'updates the petition' do

--- a/spec/controllers/admin/petition_emails_controller_spec.rb
+++ b/spec/controllers/admin/petition_emails_controller_spec.rb
@@ -208,7 +208,7 @@ RSpec.describe Admin::PetitionEmailsController, type: :controller, admin: true d
           describe "with valid params" do
             it "redirects to the petition emails page" do
               do_post
-              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}/emails"
+              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}/emails"
             end
 
             it "tells the moderator that their email will be sent overnight" do
@@ -378,7 +378,7 @@ RSpec.describe Admin::PetitionEmailsController, type: :controller, admin: true d
           describe "with valid params" do
             it "redirects to the petition emails page" do
               do_post
-              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}/emails"
+              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}/emails"
             end
 
             it "tells the moderator that their changes were saved" do
@@ -516,7 +516,7 @@ RSpec.describe Admin::PetitionEmailsController, type: :controller, admin: true d
           describe "with valid params" do
             it "redirects to the petition emails page" do
               do_post
-              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}/emails"
+              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}/emails"
             end
 
             it "tells the moderator that their changes were saved" do
@@ -736,7 +736,7 @@ RSpec.describe Admin::PetitionEmailsController, type: :controller, admin: true d
           describe "with valid params" do
             it "redirects to the petition emails page" do
               do_patch
-              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}/emails"
+              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}/emails"
             end
 
             it "tells the moderator that their email will be sent overnight" do
@@ -916,7 +916,7 @@ RSpec.describe Admin::PetitionEmailsController, type: :controller, admin: true d
           describe "with valid params" do
             it "redirects to the petition emails page" do
               do_patch
-              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}/emails"
+              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}/emails"
             end
 
             it "tells the moderator that their changes were saved" do
@@ -1059,7 +1059,7 @@ RSpec.describe Admin::PetitionEmailsController, type: :controller, admin: true d
           describe "with valid params" do
             it "redirects to the petition emails page" do
               do_patch
-              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}/emails"
+              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}/emails"
             end
 
             it "tells the moderator that their changes were saved" do
@@ -1232,7 +1232,7 @@ RSpec.describe Admin::PetitionEmailsController, type: :controller, admin: true d
 
           it "redirects to the petition emails page" do
             do_delete
-            expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}/emails"
+            expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}/emails"
           end
 
           it "tells the moderator that the record was deleted" do
@@ -1248,7 +1248,7 @@ RSpec.describe Admin::PetitionEmailsController, type: :controller, admin: true d
 
           it "redirects to the petition emails page" do
             do_delete
-            expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}/emails"
+            expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}/emails"
           end
 
           it "tells the moderator to contact support" do

--- a/spec/controllers/admin/petition_statistics_controller_spec.rb
+++ b/spec/controllers/admin/petition_statistics_controller_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe Admin::PetitionStatisticsController, type: :controller, admin: tr
       end
 
       it "redirects to the petition page" do
-        expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+        expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
       end
 
       it "sets the flash notice message" do

--- a/spec/controllers/admin/petition_tags_controller_spec.rb
+++ b/spec/controllers/admin/petition_tags_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Admin::PetitionTagsController, type: :controller, admin: true do
         end
 
         it "redirects to the petition page" do
-          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
         end
 
         it "sets the flash notice message" do

--- a/spec/controllers/admin/petition_topics_controller_spec.rb
+++ b/spec/controllers/admin/petition_topics_controller_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe Admin::PetitionTopicsController, type: :controller, admin: true d
         end
 
         it "redirects to the petition page" do
-          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
         end
 
         it "sets the flash notice message" do
@@ -93,7 +93,7 @@ RSpec.describe Admin::PetitionTopicsController, type: :controller, admin: true d
         end
 
         it "redirects to the petition page" do
-          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+          expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
         end
 
         it "sets the flash notice message" do

--- a/spec/controllers/admin/schedule_debate_controller_spec.rb
+++ b/spec/controllers/admin/schedule_debate_controller_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe Admin::ScheduleDebateController, type: :controller, admin: true d
           describe 'with valid params' do
             it 'redirects to the petition show page' do
               do_patch
-              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}"
+              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}"
             end
 
             it 'tells the moderator that their email will be sent overnight' do
@@ -288,7 +288,7 @@ RSpec.describe Admin::ScheduleDebateController, type: :controller, admin: true d
           describe 'with valid params' do
             it 'redirects to the petition show page' do
               do_patch
-              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}"
+              expect(response).to redirect_to "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}"
             end
 
             it 'tells the moderator that their changes were saved' do

--- a/spec/controllers/admin/take_down_controller_spec.rb
+++ b/spec/controllers/admin/take_down_controller_spec.rb
@@ -138,7 +138,7 @@ RSpec.describe Admin::TakeDownController, type: :controller, admin: true do
           end
 
           it 'redirects to the admin show page for the petition' do
-            expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+            expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
           end
 
           it "sends an email to the petition creator" do
@@ -179,7 +179,7 @@ RSpec.describe Admin::TakeDownController, type: :controller, admin: true do
           end
 
           it 'redirects to the admin show page for the petition' do
-            expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}")
+            expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
           end
 
           it "sends an email to the petition creator" do

--- a/spec/controllers/admin/trending_domains_controller_spec.rb
+++ b/spec/controllers/admin/trending_domains_controller_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe Admin::TrendingDomainsController, type: :controller, admin: true do
   context "when not logged in" do
-    describe "GET /admin/petitions/200000/trending-domains" do
+    describe "GET /admin/petitions/PE200000/trending-domains" do
       before do
-        get :index, params: { petition_id: "200000" }
+        get :index, params: { petition_id: "PE200000" }
       end
 
       it "redirects to the login page" do
@@ -20,9 +20,9 @@ RSpec.describe Admin::TrendingDomainsController, type: :controller, admin: true 
       login_as(user)
     end
 
-    describe "GET /admin/petitions/200000/trending-domains" do
+    describe "GET /admin/petitions/PE200000/trending-domains" do
       before do
-        get :index, params: { petition_id: "200000" }
+        get :index, params: { petition_id: "PE200000" }
       end
 
       it "redirects to edit profile page" do
@@ -42,9 +42,9 @@ RSpec.describe Admin::TrendingDomainsController, type: :controller, admin: true 
       login_as(user)
     end
 
-    describe "GET /admin/petitions/200000/trending-domains" do
+    describe "GET /admin/petitions/PE200000/trending-domains" do
       before do
-        allow(Petition).to receive(:find).with("200000").and_return(petition)
+        allow(Petition).to receive(:find).with("PE200000").and_return(petition)
         allow(petition).to receive(:trending_domains).and_return(scope)
       end
 
@@ -69,7 +69,7 @@ RSpec.describe Admin::TrendingDomainsController, type: :controller, admin: true 
       context "when viewing all trending domains" do
         before do
           expect(scope).to receive(:search).with(nil, page: nil).and_return(trending_domains)
-          get :index, params: { petition_id: "200000" }
+          get :index, params: { petition_id: "PE200000" }
         end
 
         include_examples("trending domains index page")
@@ -78,7 +78,7 @@ RSpec.describe Admin::TrendingDomainsController, type: :controller, admin: true 
       context "when viewing page 2 of all trending domains" do
         before do
           expect(scope).to receive(:search).with(nil, page: "2").and_return(trending_domains)
-          get :index, params: { petition_id: "200000", page: "2" }
+          get :index, params: { petition_id: "PE200000", page: "2" }
         end
 
         include_examples("trending domains index page")
@@ -87,7 +87,7 @@ RSpec.describe Admin::TrendingDomainsController, type: :controller, admin: true 
       context "when searching trending domains" do
         before do
           expect(scope).to receive(:search).with("example.com", page: nil).and_return(trending_domains)
-          get :index, params: { petition_id: "200000", q: "example.com" }
+          get :index, params: { petition_id: "PE200000", q: "example.com" }
         end
 
         include_examples("trending domains index page")
@@ -96,7 +96,7 @@ RSpec.describe Admin::TrendingDomainsController, type: :controller, admin: true 
       context "when viewing page 2 of a trending domains search" do
         before do
           expect(scope).to receive(:search).with("example.com", page: "2").and_return(trending_domains)
-          get :index, params: { petition_id: "200000", q: "example.com", page: "2" }
+          get :index, params: { petition_id: "PE200000", q: "example.com", page: "2" }
         end
 
         include_examples("trending domains index page")

--- a/spec/controllers/admin/trending_ips_controller_spec.rb
+++ b/spec/controllers/admin/trending_ips_controller_spec.rb
@@ -42,9 +42,9 @@ RSpec.describe Admin::TrendingIpsController, type: :controller, admin: true do
       login_as(user)
     end
 
-    describe "GET /admin/petitions/200000/trending-ips" do
+    describe "GET /admin/petitions/PE200000/trending-ips" do
       before do
-        allow(Petition).to receive(:find).with("200000").and_return(petition)
+        allow(Petition).to receive(:find).with("PE200000").and_return(petition)
         allow(petition).to receive(:trending_ips).and_return(scope)
       end
 
@@ -69,7 +69,7 @@ RSpec.describe Admin::TrendingIpsController, type: :controller, admin: true do
       context "when viewing all trending ip addresses" do
         before do
           expect(scope).to receive(:search).with(nil, page: nil).and_return(trending_ips)
-          get :index, params: { petition_id: "200000" }
+          get :index, params: { petition_id: "PE200000" }
         end
 
         include_examples("trending ip addresses index page")
@@ -78,7 +78,7 @@ RSpec.describe Admin::TrendingIpsController, type: :controller, admin: true do
       context "when viewing page 2 of all trending ip addresses" do
         before do
           expect(scope).to receive(:search).with(nil, page: "2").and_return(trending_ips)
-          get :index, params: { petition_id: "200000", page: "2" }
+          get :index, params: { petition_id: "PE200000", page: "2" }
         end
 
         include_examples("trending ip addresses index page")
@@ -87,7 +87,7 @@ RSpec.describe Admin::TrendingIpsController, type: :controller, admin: true do
       context "when searching trending ip addresses" do
         before do
           expect(scope).to receive(:search).with("127.0.0.1", page: nil).and_return(trending_ips)
-          get :index, params: { petition_id: "200000", q: "127.0.0.1" }
+          get :index, params: { petition_id: "PE200000", q: "127.0.0.1" }
         end
 
         include_examples("trending ip addresses index page")
@@ -96,7 +96,7 @@ RSpec.describe Admin::TrendingIpsController, type: :controller, admin: true do
       context "when viewing page 2 of a trending ip addresses search" do
         before do
           expect(scope).to receive(:search).with("127.0.0.1", page: "2").and_return(trending_ips)
-          get :index, params: { petition_id: "200000", q: "127.0.0.1", page: "2" }
+          get :index, params: { petition_id: "PE200000", q: "127.0.0.1", page: "2" }
         end
 
         include_examples("trending ip addresses index page")

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -255,19 +255,20 @@ RSpec.describe PetitionsController, type: :controller do
     let(:petition) { double }
 
     it "assigns the given petition" do
+      allow(petition).to receive(:pe_number_id).and_return(petition)
       allow(petition).to receive(:collecting_sponsors?).and_return(false)
       allow(petition).to receive(:in_moderation?).and_return(false)
       allow(petition).to receive(:moderated?).and_return(true)
-      allow(Petition).to receive_message_chain(:show, find: petition)
+      allow(Petition).to receive_message_chain(:show, find: petition.pe_number_id)
 
-      get :show, params: { id: 1 }
+      get :show, params: { id: "PE0002" }
       expect(assigns(:petition)).to eq(petition)
     end
 
     it "does not allow hidden petitions to be shown" do
       expect {
         allow(Petition).to receive_message_chain(:visible, :find).and_raise ActiveRecord::RecordNotFound
-        get :show, params: { id: 1 }
+        get :show, params: { id: "PP0001" }
       }.to raise_error(ActiveRecord::RecordNotFound)
     end
   end
@@ -323,6 +324,56 @@ RSpec.describe PetitionsController, type: :controller do
     it "is successful" do
       get :check_results, params: { q: "action" }
       expect(response).to be_successful
+    end
+  end
+
+  describe "GET /petitions/:id/moderation-info" do
+    let(:petition) { double }
+
+    context "when petitions do not need to collect sponsors to be submitted for moderation" do
+      before do
+        Site.instance.update!(
+          minimum_number_of_sponsors: 0,
+          threshold_for_moderation: 0
+        )
+      end
+
+      it "redirects to not found" do
+        allow(petition).to receive(:collecting_sponsors?).and_return(false)
+        allow(petition).to receive(:in_moderation?).and_return(false)
+        allow(petition).to receive(:moderated?).and_return(true)
+        allow(petition).to receive(:pe_number_id).and_return(petition)
+        allow(Petition).to receive_message_chain(:show, find: petition.pe_number_id)
+
+        expect {
+          get :moderation_info, params: { id: "PP0001" }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
+    end
+  end
+
+  describe "GET /petitions/:id/gathering-support" do
+    let(:petition) { double }
+
+    context "when petitions do not need to collect sponsors to be submitted for moderation" do
+      before do
+        Site.instance.update!(
+          minimum_number_of_sponsors: 0,
+          threshold_for_moderation: 0
+        )
+      end
+
+      it "redirects to not found" do
+        allow(petition).to receive(:collecting_sponsors?).and_return(false)
+        allow(petition).to receive(:in_moderation?).and_return(false)
+        allow(petition).to receive(:moderated?).and_return(true)
+        allow(petition).to receive(:pe_number_id).and_return(petition)
+        allow(Petition).to receive_message_chain(:show, find: petition.pe_number_id)
+
+        expect {
+          get :gathering_support, params: { id: "PP0001" }
+        }.to raise_error(ActiveRecord::RecordNotFound)
+      end
     end
   end
 end

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -27,21 +27,35 @@ RSpec.describe SignaturesController, type: :controller do
       end
     end
 
-    %w[closed rejected].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
+    context "when the petition is closed" do
+      let(:petition) { FactoryBot.create(:closed_petition) }
 
-        before do
-          get :new, params: { petition_id: petition.id }
-        end
+      before do
+        get :new, params: { petition_id: petition.id }
+      end
 
-        it "assigns the @petition instance variable" do
-          expect(assigns[:petition]).to eq(petition)
-        end
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
 
-        it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
-        end
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
+      end
+    end
+
+    context "when the petition is rejected" do
+      let(:petition) { FactoryBot.create(:rejected_petition) }
+
+      before do
+        get :new, params: { petition_id: petition.id }
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -100,21 +114,35 @@ RSpec.describe SignaturesController, type: :controller do
       end
     end
 
-    %w[closed rejected].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
+    context "when the petition is closed" do
+      let(:petition) { FactoryBot.create(:closed_petition) }
 
-        before do
-          post :confirm, params: { petition_id: petition.id, signature: params }
-        end
+      before do
+        post :confirm, params: { petition_id: petition.id, signature: params }
+      end
 
-        it "assigns the @petition instance variable" do
-          expect(assigns[:petition]).to eq(petition)
-        end
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
 
-        it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
-        end
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
+      end
+    end
+
+    context "when the petition is rejected" do
+      let(:petition) { FactoryBot.create(:rejected_petition) }
+
+      before do
+        post :confirm, params: { petition_id: petition.id, signature: params }
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -212,21 +240,35 @@ RSpec.describe SignaturesController, type: :controller do
       end
     end
 
-    %w[closed rejected].each do |state|
-      context "when the petition is #{state}" do
-        let(:petition) { FactoryBot.create(:"#{state}_petition") }
+    context "when the petition is closed" do
+      let(:petition) { FactoryBot.create(:closed_petition) }
 
-        before do
-          post :create, params: { petition_id: petition.id, signature: params }
-        end
+      before do
+        post :confirm, params: { petition_id: petition.id, signature: params }
+      end
 
-        it "assigns the @petition instance variable" do
-          expect(assigns[:petition]).to eq(petition)
-        end
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
 
-        it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
-        end
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
+      end
+    end
+
+    context "when the petition is rejected" do
+      let(:petition) { FactoryBot.create(:rejected_petition) }
+
+      before do
+        post :confirm, params: { petition_id: petition.id, signature: params }
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -266,7 +308,7 @@ RSpec.describe SignaturesController, type: :controller do
         end
 
         it "redirects to the thank you page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}/signatures/thank-you")
         end
 
         context "and the user is on the English domain" do
@@ -324,7 +366,7 @@ RSpec.describe SignaturesController, type: :controller do
         end
 
         it "redirects to the thank you page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}/signatures/thank-you")
         end
       end
 
@@ -353,7 +395,7 @@ RSpec.describe SignaturesController, type: :controller do
         end
 
         it "redirects to the thank you page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}/signatures/thank-you")
         end
       end
 
@@ -380,7 +422,7 @@ RSpec.describe SignaturesController, type: :controller do
         end
 
         it "redirects to the thank you page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}/signatures/thank-you")
         end
       end
 
@@ -409,7 +451,7 @@ RSpec.describe SignaturesController, type: :controller do
         end
 
         it "redirects to the thank you page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/signatures/thank-you")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}/signatures/thank-you")
         end
       end
     end
@@ -452,7 +494,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -473,7 +515,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -494,7 +536,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -592,7 +634,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -617,7 +659,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -729,7 +771,7 @@ RSpec.describe SignaturesController, type: :controller do
 
       it "redirects to the petition page" do
         get :signed, params: { id: signature.id }
-        expect(response).to redirect_to("/petitions/#{petition.id}")
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -785,7 +827,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -806,7 +848,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "redirects to the petition page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}")
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -870,7 +912,7 @@ RSpec.describe SignaturesController, type: :controller do
           let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
 
           it "doesn't redirect to the petition page" do
-            expect(response).not_to redirect_to("/petitions/#{petition.id}")
+            expect(response).not_to redirect_to("/petitions/#{petition.to_param}")
           end
         end
       end
@@ -883,7 +925,7 @@ RSpec.describe SignaturesController, type: :controller do
         end
 
         it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}")
         end
       end
     end

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -50,7 +50,7 @@ RSpec.describe SponsorsController, type: :controller do
       end
     end
 
-    %w[open closed rejected].each do |state|
+    %w[open closed].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -63,8 +63,24 @@ RSpec.describe SponsorsController, type: :controller do
         end
 
         it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}")
         end
+      end
+    end
+
+    context "when the petition is rejected" do
+      let(:petition) { FactoryBot.create(:rejected_petition) }
+
+      before do
+        get :new, params: { petition_id: petition.id, token: petition.sponsor_token }
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -96,7 +112,7 @@ RSpec.describe SponsorsController, type: :controller do
           let(:petition) { FactoryBot.create(:"#{state}_petition", sponsor_count: Site.maximum_number_of_sponsors - 1, sponsors_signed: true) }
 
           it "doesn't redirect to the petition moderation info page" do
-            expect(response).not_to redirect_to("/petitions/#{petition.id}/moderation-info")
+            expect(response).not_to redirect_to("/petitions/#{petition.to_param}/moderation-info")
           end
         end
 
@@ -104,7 +120,7 @@ RSpec.describe SponsorsController, type: :controller do
           let(:petition) { FactoryBot.create(:"#{state}_petition", sponsor_count: Site.maximum_number_of_sponsors, sponsors_signed: true) }
 
           it "redirects to the petition moderation info page" do
-            expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+            expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
           end
         end
       end
@@ -151,7 +167,7 @@ RSpec.describe SponsorsController, type: :controller do
       end
     end
 
-    %w[open closed rejected].each do |state|
+    %w[open closed].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -164,8 +180,24 @@ RSpec.describe SponsorsController, type: :controller do
         end
 
         it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}")
         end
+      end
+    end
+
+    context "when the petition is rejected" do
+      let(:petition) { FactoryBot.create(:rejected_petition) }
+
+      before do
+        post :confirm, params: { petition_id: petition.id, token: petition.sponsor_token, signature: params }
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -236,7 +268,7 @@ RSpec.describe SponsorsController, type: :controller do
           let(:petition) { FactoryBot.create(:"#{state}_petition", sponsor_count: Site.maximum_number_of_sponsors - 1, sponsors_signed: true) }
 
           it "doesn't redirect to the petition moderation info page" do
-            expect(response).not_to redirect_to("/petitions/#{petition.id}/moderation-info")
+            expect(response).not_to redirect_to("/petitions/#{petition.to_param}/moderation-info")
           end
         end
 
@@ -244,7 +276,7 @@ RSpec.describe SponsorsController, type: :controller do
           let(:petition) { FactoryBot.create(:"#{state}_petition", sponsor_count: Site.maximum_number_of_sponsors, sponsors_signed: true) }
 
           it "redirects to the petition moderation info page" do
-            expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+            expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
           end
         end
       end
@@ -291,7 +323,7 @@ RSpec.describe SponsorsController, type: :controller do
       end
     end
 
-    %w[open closed rejected].each do |state|
+    %w[open closed].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
 
@@ -304,8 +336,24 @@ RSpec.describe SponsorsController, type: :controller do
         end
 
         it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}")
         end
+      end
+    end
+
+    context "when the petition is rejected" do
+      let(:petition) { FactoryBot.create(:rejected_petition) }
+
+      before do
+        post :create, params: { petition_id: petition.id, token: petition.sponsor_token, signature: params }
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -346,7 +394,7 @@ RSpec.describe SponsorsController, type: :controller do
           end
 
           it "redirects to the thank you page" do
-            expect(response).to redirect_to("/petitions/#{petition.id}/sponsors/thank-you?token=#{petition.sponsor_token}")
+            expect(response).to redirect_to("/petitions/#{petition.to_param}/sponsors/thank-you?token=#{petition.sponsor_token}")
           end
 
           context "and the user is on the English domain" do
@@ -404,7 +452,7 @@ RSpec.describe SponsorsController, type: :controller do
           end
 
           it "redirects to the thank you page" do
-            expect(response).to redirect_to("/petitions/#{petition.id}/sponsors/thank-you?token=#{petition.sponsor_token}")
+            expect(response).to redirect_to("/petitions/#{petition.to_param}/sponsors/thank-you?token=#{petition.sponsor_token}")
           end
         end
 
@@ -433,7 +481,7 @@ RSpec.describe SponsorsController, type: :controller do
           end
 
           it "redirects to the thank you page" do
-            expect(response).to redirect_to("/petitions/#{petition.id}/sponsors/thank-you?token=#{petition.sponsor_token}")
+            expect(response).to redirect_to("/petitions/#{petition.to_param}/sponsors/thank-you?token=#{petition.sponsor_token}")
           end
         end
 
@@ -461,7 +509,7 @@ RSpec.describe SponsorsController, type: :controller do
           end
 
           it "redirects to the thank you page" do
-            expect(response).to redirect_to("/petitions/#{petition.id}/sponsors/thank-you?token=#{petition.sponsor_token}")
+            expect(response).to redirect_to("/petitions/#{petition.to_param}/sponsors/thank-you?token=#{petition.sponsor_token}")
           end
         end
 
@@ -490,7 +538,7 @@ RSpec.describe SponsorsController, type: :controller do
           end
 
           it "redirects to the thank you page" do
-            expect(response).to redirect_to("/petitions/#{petition.id}/sponsors/thank-you?token=#{petition.sponsor_token}")
+            expect(response).to redirect_to("/petitions/#{petition.to_param}/sponsors/thank-you?token=#{petition.sponsor_token}")
           end
         end
 
@@ -504,7 +552,7 @@ RSpec.describe SponsorsController, type: :controller do
           end
 
           it "doesn't redirect to the petition moderation info page" do
-            expect(response).not_to redirect_to("/petitions/#{petition.id}/moderation-info")
+            expect(response).not_to redirect_to("/petitions/##{petition.to_param}/moderation-info")
           end
         end
 
@@ -518,7 +566,7 @@ RSpec.describe SponsorsController, type: :controller do
           end
 
           it "redirects to the petition moderation info page" do
-            expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+            expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
           end
         end
       end
@@ -569,7 +617,7 @@ RSpec.describe SponsorsController, type: :controller do
         end
 
         it "doesn't redirect to the petition page" do
-          expect(response).not_to redirect_to("/petitions/#{petition.id}")
+          expect(response).not_to redirect_to("/petitions/#{petition.to_param}}")
         end
 
         it "renders the signatures/thank_you template" do
@@ -599,7 +647,7 @@ RSpec.describe SponsorsController, type: :controller do
           let(:petition) { FactoryBot.create(:"#{state}_petition", sponsor_count: Site.maximum_number_of_sponsors - 1, sponsors_signed: true) }
 
           it "doesn't redirect to the petition moderation info page" do
-            expect(response).not_to redirect_to("/petitions/#{petition.id}/moderation-info")
+            expect(response).not_to redirect_to("/petitions/#{petition.to_param}/moderation-info")
           end
 
           it "renders the signatures/thank_you template" do
@@ -611,7 +659,7 @@ RSpec.describe SponsorsController, type: :controller do
           let(:petition) { FactoryBot.create(:"#{state}_petition", sponsor_count: Site.maximum_number_of_sponsors, sponsors_signed: true) }
 
           it "doesn't redirect to the petition moderation info page" do
-            expect(response).not_to redirect_to("/petitions/#{petition.id}/moderation-info")
+            expect(response).not_to redirect_to("/petitions/#{petition.to_param}/moderation-info")
           end
 
           it "renders the signatures/thank_you template" do
@@ -677,7 +725,7 @@ RSpec.describe SponsorsController, type: :controller do
       end
     end
 
-    %w[open closed rejected].each do |state|
+    %w[open closed].each do |state|
       context "when the petition is #{state}" do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
         let(:signature) { FactoryBot.create(:pending_signature, petition: petition, sponsor: true) }
@@ -695,8 +743,29 @@ RSpec.describe SponsorsController, type: :controller do
         end
 
         it "redirects to the petition page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}")
         end
+      end
+    end
+
+    context "when the petition is rejected" do
+      let(:petition) { FactoryBot.create(:rejected_petition) }
+      let(:signature) { FactoryBot.create(:pending_signature, petition: petition, sponsor: true) }
+
+      before do
+        get :verify, params: { id: signature.id, token: signature.perishable_token }
+      end
+
+      it "assigns the @signature instance variable" do
+        expect(assigns[:signature]).to eq(signature)
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
@@ -839,7 +908,7 @@ RSpec.describe SponsorsController, type: :controller do
         let(:signature) { FactoryBot.create(:validated_signature, validated_at: 30.minutes.ago, petition: petition, sponsor: true) }
 
         it "redirects to the new sponsor page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}")
         end
       end
 
@@ -913,7 +982,7 @@ RSpec.describe SponsorsController, type: :controller do
         let(:petition) { FactoryBot.create(:validated_petition, sponsor_count: Site.maximum_number_of_sponsors, sponsors_signed: true) }
 
         it "redirects to the petition moderation info page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
         end
       end
     end
@@ -1014,7 +1083,7 @@ RSpec.describe SponsorsController, type: :controller do
         let(:petition) { FactoryBot.create(:sponsored_petition, sponsor_count: Site.maximum_number_of_sponsors, sponsors_signed: true) }
 
         it "redirects to the petition moderation info page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+          expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
         end
       end
     end
@@ -1035,7 +1104,7 @@ RSpec.describe SponsorsController, type: :controller do
 
       it "redirects to the petition moderation info page" do
         get :signed, params: { id: signature.id }
-        expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+        expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
       end
     end
 
@@ -1093,7 +1162,7 @@ RSpec.describe SponsorsController, type: :controller do
         end
 
         it "doesn't redirect to the petition page" do
-          expect(response).not_to redirect_to("/petitions/#{petition.id}")
+          expect(response).not_to redirect_to("/petitions/#{petition.to_param}")
         end
 
         it "renders the sponsors/signed template" do
@@ -1198,7 +1267,7 @@ RSpec.describe SponsorsController, type: :controller do
           end
 
           it "redirects to the petition moderation info page" do
-            expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+            expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
           end
         end
       end

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -44,6 +44,10 @@ FactoryBot.define do
       locale { "gd-GB" }
     end
 
+    before(:create) do |petition|
+      petition.build_pe_number if petition.visible?
+    end
+
     after(:build) do |petition, evaluator|
       unless petition.creator
         petition.creator = evaluator.creator
@@ -703,5 +707,8 @@ FactoryBot.define do
     trait :hidden do
       hidden { true }
     end
+  end
+
+  factory :pe_number do
   end
 end

--- a/spec/helpers/sharing_helper_spec.rb
+++ b/spec/helpers/sharing_helper_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe SharingHelper, type: :helper do
     describe "#share_via_facebook" do
       it "generates a share via Facebook link" do
         expect(helper.share_via_facebook(petition)).to eq <<-URL.strip
-          <a rel="external" target="_blank" href="https://www.facebook.com/sharer/sharer.php?ref=responsive&amp;u=https%3A%2F%2Fpetitions.parliament.scot%2Fpetitions%2F100000">Facebook</a>
+          <a rel="external" target="_blank" href="https://www.facebook.com/sharer/sharer.php?ref=responsive&amp;u=https%3A%2F%2Fpetitions.parliament.scot%2Fpetitions%2F#{petition.to_param}">Facebook</a>
         URL
       end
     end
@@ -26,7 +26,7 @@ RSpec.describe SharingHelper, type: :helper do
     describe "#share_via_email" do
       it "generates a share via email link" do
         expect(helper.share_via_email(petition)).to eq <<-URL.strip
-          <a rel="external" target="_blank" href="mailto:?body=https%3A%2F%2Fpetitions.parliament.scot%2Fpetitions%2F100000&amp;subject=Petition%3A%20Do%20Something%21">Email</a>
+          <a rel="external" target="_blank" href="mailto:?body=https%3A%2F%2Fpetitions.parliament.scot%2Fpetitions%2F#{petition.to_param}&amp;subject=Petition%3A%20Do%20Something%21">Email</a>
         URL
       end
     end
@@ -34,7 +34,7 @@ RSpec.describe SharingHelper, type: :helper do
     describe "#share_via_twitter" do
       it "generates a share via Twitter link" do
         expect(helper.share_via_twitter(petition)).to eq <<-URL.strip
-          <a rel="external" target="_blank" href="https://twitter.com/intent/tweet?text=Petition%3A%20Do%20Something%21&amp;url=https%3A%2F%2Fpetitions.parliament.scot%2Fpetitions%2F100000">Twitter</a>
+          <a rel="external" target="_blank" href="https://twitter.com/intent/tweet?text=Petition%3A%20Do%20Something%21&amp;url=https%3A%2F%2Fpetitions.parliament.scot%2Fpetitions%2F#{petition.to_param}">Twitter</a>
         URL
       end
     end
@@ -42,7 +42,7 @@ RSpec.describe SharingHelper, type: :helper do
     describe "#share_via_whatsapp" do
       it "generates a share via Whatsapp link" do
         expect(helper.share_via_whatsapp(petition)).to eq <<-URL.strip
-          <a rel="external" target="_blank" href="whatsapp://send?text=Petition%3A%20Do%20Something%21%0Ahttps%3A%2F%2Fpetitions.parliament.scot%2Fpetitions%2F100000">Whatsapp</a>
+          <a rel="external" target="_blank" href="whatsapp://send?text=Petition%3A%20Do%20Something%21%0Ahttps%3A%2F%2Fpetitions.parliament.scot%2Fpetitions%2F#{petition.to_param}">Whatsapp</a>
         URL
       end
     end
@@ -57,7 +57,7 @@ RSpec.describe SharingHelper, type: :helper do
     describe "#share_via_facebook" do
       it "generates a share via Facebook link" do
         expect(helper.share_via_facebook(petition)).to eq <<-URL.strip
-          <a rel="external" target="_blank" href="https://www.facebook.com/sharer/sharer.php?ref=responsive&amp;u=https%3A%2F%2Fathchuingean.parlamaid-alba.scot%2Fathchuingean%2F100000">Facebook</a>
+          <a rel="external" target="_blank" href="https://www.facebook.com/sharer/sharer.php?ref=responsive&amp;u=https%3A%2F%2Fathchuingean.parlamaid-alba.scot%2Fathchuingean%2F#{petition.to_param}">Facebook</a>
         URL
       end
     end
@@ -65,7 +65,7 @@ RSpec.describe SharingHelper, type: :helper do
     describe "#share_via_email" do
       it "generates a share via email link" do
         expect(helper.share_via_email(petition)).to eq <<-URL.strip
-          <a rel="external" target="_blank" href="mailto:?body=https%3A%2F%2Fathchuingean.parlamaid-alba.scot%2Fathchuingean%2F100000&amp;subject=Athchuinge%3A%20D%C3%A8an%20Rudeigin%21">Post-d</a>
+          <a rel="external" target="_blank" href="mailto:?body=https%3A%2F%2Fathchuingean.parlamaid-alba.scot%2Fathchuingean%2F#{petition.to_param}&amp;subject=Athchuinge%3A%20D%C3%A8an%20Rudeigin%21">Post-d</a>
         URL
       end
     end
@@ -73,7 +73,7 @@ RSpec.describe SharingHelper, type: :helper do
     describe "#share_via_twitter" do
       it "generates a share via Twitter link" do
         expect(helper.share_via_twitter(petition)).to eq <<-URL.strip
-          <a rel="external" target="_blank" href="https://twitter.com/intent/tweet?text=Athchuinge%3A%20D%C3%A8an%20Rudeigin%21&amp;url=https%3A%2F%2Fathchuingean.parlamaid-alba.scot%2Fathchuingean%2F100000">Twitter</a>
+          <a rel="external" target="_blank" href="https://twitter.com/intent/tweet?text=Athchuinge%3A%20D%C3%A8an%20Rudeigin%21&amp;url=https%3A%2F%2Fathchuingean.parlamaid-alba.scot%2Fathchuingean%2F#{petition.to_param}">Twitter</a>
         URL
       end
     end
@@ -81,7 +81,7 @@ RSpec.describe SharingHelper, type: :helper do
     describe "#share_via_whatsapp" do
       it "generates a share via Whatsapp link" do
         expect(helper.share_via_whatsapp(petition)).to eq <<-URL.strip
-          <a rel="external" target="_blank" href="whatsapp://send?text=Athchuinge%3A%20D%C3%A8an%20Rudeigin%21%0Ahttps%3A%2F%2Fathchuingean.parlamaid-alba.scot%2Fathchuingean%2F100000">Whatsapp</a>
+          <a rel="external" target="_blank" href="whatsapp://send?text=Athchuinge%3A%20D%C3%A8an%20Rudeigin%21%0Ahttps%3A%2F%2Fathchuingean.parlamaid-alba.scot%2Fathchuingean%2F#{petition.to_param}">Whatsapp</a>
         URL
       end
     end

--- a/spec/jobs/notify_job_spec.rb
+++ b/spec/jobs/notify_job_spec.rb
@@ -323,8 +323,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Do stuff",
                   content: "Because of reasons\n\nHere's some more reasons",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -346,8 +346,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Do stuff",
                   content: "Because of reasons\n\nHere's some more reasons",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -371,8 +371,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Do stuff",
                   content: "Because of reasons\n\nHere's some more reasons",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -394,8 +394,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Do stuff",
                   content: "Because of reasons\n\nHere's some more reasons",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -419,8 +419,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Do stuff",
                   content: "Because of reasons\n\nHere's some more reasons",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -442,8 +442,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Do stuff",
                   content: "Because of reasons\n\nHere's some more reasons",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -482,8 +482,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Dèan stuth",
                   content: "Air sgàth adhbharan\n\nSeo beagan a bharrachd adhbharan",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -505,8 +505,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Dèan stuth",
                   content: "Air sgàth adhbharan\n\nSeo beagan a bharrachd adhbharan",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -530,8 +530,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Dèan stuth",
                   content: "Air sgàth adhbharan\n\nSeo beagan a bharrachd adhbharan",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -553,8 +553,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Dèan stuth",
                   content: "Air sgàth adhbharan\n\nSeo beagan a bharrachd adhbharan",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -578,8 +578,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Dèan stuth",
                   content: "Air sgàth adhbharan\n\nSeo beagan a bharrachd adhbharan",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -601,8 +601,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   action: "Dèan stuth",
                   content: "Air sgàth adhbharan\n\nSeo beagan a bharrachd adhbharan",
                   creator: "Charlie",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}/luchd-taic/ur?token=#{petition.sponsor_token}"
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}/luchd-taic/ur?token=#{petition.sponsor_token}"
                 }
               )).to have_been_made
             end
@@ -1100,8 +1100,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
             personalisation: {
               action_en: "Do stuff",
               action_gd: "Dèan stuth",
-              url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}"
+              url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}"
             }
           )).to have_been_made
         end
@@ -1132,8 +1132,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
             personalisation: {
               action_en: "Do stuff",
               action_gd: "Dèan stuth",
-              url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}"
+              url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}"
             }
           )).to have_been_made
         end
@@ -1189,8 +1189,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
             personalisation: {
               creator: "Charlie",
               action_en: "Do stuff", action_gd: "Dèan stuth",
-              url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}"
+              url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}"
             }
           )).to have_been_made
         end
@@ -1227,8 +1227,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
             personalisation: {
               creator: "Charlie",
               action_en: "Do stuff", action_gd: "Dèan stuth",
-              url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}"
+              url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}"
             }
           )).to have_been_made
         end
@@ -1285,8 +1285,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 sponsor: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}"
+                url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}"
               }
             )).to have_been_made
           end
@@ -1316,8 +1316,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 sponsor: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}"
+                url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}"
               }
             )).to have_been_made
           end
@@ -1367,8 +1367,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 sponsor: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}"
+                url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}"
               }
             )).to have_been_made
           end
@@ -1398,8 +1398,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 sponsor: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}"
+                url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}"
               }
             )).to have_been_made
           end
@@ -1453,8 +1453,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 creator: "Charlie", action: "Do stuff",
                 content_en: "There’s already a petition about this issue. We cannot accept a new petition when we already have one about a very similar issue, or if the Petitions Committee has considered one in the last year.",
                 content_gd: "Tha athchuinge ann mu thràth mun chùis seo. Chan urrainn dhuinn gabhail ri athchuinge ùr nuair a tha fear againn mu chùis glè choltach mu thràth, no ma tha Comataidh nan Athchuingean air beachdachadh air fear sa bhliadhna a dh ’fhalbh.",
-                url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 standards_url_en: "https://petitions.parliament.scot/help#standards",
                 standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards",
                 new_petition_url_en: "https://petitions.parliament.scot/petitions/check",
@@ -1481,8 +1481,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 creator: "Charlie", action: "Do stuff",
                 content_en: "It’s offensive, nonsense, a joke, or an advert.",
                 content_gd: "Tha e oilbheumach, neoni, fealla-dhà no sanas.",
-                url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 standards_url_en: "https://petitions.parliament.scot/help#standards",
                 standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards",
                 new_petition_url_en: "https://petitions.parliament.scot/petitions/check",
@@ -1509,8 +1509,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 creator: "Charlie", action_en: "Do stuff", action_gd: "Dèan stuth",
                 content_en: "It did not collect enough signatures to be referred to the Petitions Committee.\n\nPetitions need to receive at least 50 signatures before they can be considered in Parliament.",
                 content_gd: "Cha do chruinnich e ainmean-sgrìobhte gu leòr airson an cur gu Comataidh nan Athchuingean.\n\nFeumaidh athchuingean co-dhiù 50 ainm-sgrìobhte fhaighinn mus tèid beachdachadh orra anns a ’Phàrlamaid.",
-                url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 standards_url_en: "https://petitions.parliament.scot/help#standards",
                 standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards",
                 new_petition_url_en: "https://petitions.parliament.scot/petitions/check",
@@ -1557,8 +1557,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 creator: "Charlie", action: "Dèan stuth",
                 content_en: "There’s already a petition about this issue. We cannot accept a new petition when we already have one about a very similar issue, or if the Petitions Committee has considered one in the last year.",
                 content_gd: "Tha athchuinge ann mu thràth mun chùis seo. Chan urrainn dhuinn gabhail ri athchuinge ùr nuair a tha fear againn mu chùis glè choltach mu thràth, no ma tha Comataidh nan Athchuingean air beachdachadh air fear sa bhliadhna a dh ’fhalbh.",
-                url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 standards_url_en: "https://petitions.parliament.scot/help#standards",
                 standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards",
                 new_petition_url_en: "https://petitions.parliament.scot/petitions/check",
@@ -1585,8 +1585,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 creator: "Charlie", action: "Dèan stuth",
                 content_en: "It’s offensive, nonsense, a joke, or an advert.",
                 content_gd: "Tha e oilbheumach, neoni, fealla-dhà no sanas.",
-                url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 standards_url_en: "https://petitions.parliament.scot/help#standards",
                 standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards",
                 new_petition_url_en: "https://petitions.parliament.scot/petitions/check",
@@ -1613,8 +1613,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 creator: "Charlie", action_en: "Do stuff", action_gd: "Dèan stuth",
                 content_en: "It did not collect enough signatures to be referred to the Petitions Committee.\n\nPetitions need to receive at least 50 signatures before they can be considered in Parliament.",
                 content_gd: "Cha do chruinnich e ainmean-sgrìobhte gu leòr airson an cur gu Comataidh nan Athchuingean.\n\nFeumaidh athchuingean co-dhiù 50 ainm-sgrìobhte fhaighinn mus tèid beachdachadh orra anns a ’Phàrlamaid.",
-                url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 standards_url_en: "https://petitions.parliament.scot/help#standards",
                 standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards",
                 new_petition_url_en: "https://petitions.parliament.scot/petitions/check",
@@ -1684,8 +1684,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action: "Do stuff",
                   content_en: "There’s already a petition about this issue. We cannot accept a new petition when we already have one about a very similar issue, or if the Petitions Committee has considered one in the last year.",
                   content_gd: "Tha athchuinge ann mu thràth mun chùis seo. Chan urrainn dhuinn gabhail ri athchuinge ùr nuair a tha fear againn mu chùis glè choltach mu thràth, no ma tha Comataidh nan Athchuingean air beachdachadh air fear sa bhliadhna a dh ’fhalbh.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -1718,8 +1718,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action: "Do stuff",
                   content_en: "There’s already a petition about this issue. We cannot accept a new petition when we already have one about a very similar issue, or if the Petitions Committee has considered one in the last year.",
                   content_gd: "Tha athchuinge ann mu thràth mun chùis seo. Chan urrainn dhuinn gabhail ri athchuinge ùr nuair a tha fear againn mu chùis glè choltach mu thràth, no ma tha Comataidh nan Athchuingean air beachdachadh air fear sa bhliadhna a dh ’fhalbh.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -1757,8 +1757,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action: "Do stuff",
                   content_en: "It’s offensive, nonsense, a joke, or an advert.",
                   content_gd: "Tha e oilbheumach, neoni, fealla-dhà no sanas.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -1791,8 +1791,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action: "Do stuff",
                   content_en: "It’s offensive, nonsense, a joke, or an advert.",
                   content_gd: "Tha e oilbheumach, neoni, fealla-dhà no sanas.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -1830,8 +1830,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action_en: "Do stuff", action_gd: "Dèan stuth",
                   content_en: "It did not collect enough signatures to be referred to the Petitions Committee.\n\nPetitions need to receive at least 50 signatures before they can be considered in Parliament.",
                   content_gd: "Cha do chruinnich e ainmean-sgrìobhte gu leòr airson an cur gu Comataidh nan Athchuingean.\n\nFeumaidh athchuingean co-dhiù 50 ainm-sgrìobhte fhaighinn mus tèid beachdachadh orra anns a ’Phàrlamaid.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -1864,8 +1864,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action_en: "Do stuff", action_gd: "Dèan stuth",
                   content_en: "It did not collect enough signatures to be referred to the Petitions Committee.\n\nPetitions need to receive at least 50 signatures before they can be considered in Parliament.",
                   content_gd: "Cha do chruinnich e ainmean-sgrìobhte gu leòr airson an cur gu Comataidh nan Athchuingean.\n\nFeumaidh athchuingean co-dhiù 50 ainm-sgrìobhte fhaighinn mus tèid beachdachadh orra anns a ’Phàrlamaid.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -1923,8 +1923,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action: "Dèan stuth",
                   content_en: "There’s already a petition about this issue. We cannot accept a new petition when we already have one about a very similar issue, or if the Petitions Committee has considered one in the last year.",
                   content_gd: "Tha athchuinge ann mu thràth mun chùis seo. Chan urrainn dhuinn gabhail ri athchuinge ùr nuair a tha fear againn mu chùis glè choltach mu thràth, no ma tha Comataidh nan Athchuingean air beachdachadh air fear sa bhliadhna a dh ’fhalbh.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -1957,8 +1957,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action: "Dèan stuth",
                   content_en: "There’s already a petition about this issue. We cannot accept a new petition when we already have one about a very similar issue, or if the Petitions Committee has considered one in the last year.",
                   content_gd: "Tha athchuinge ann mu thràth mun chùis seo. Chan urrainn dhuinn gabhail ri athchuinge ùr nuair a tha fear againn mu chùis glè choltach mu thràth, no ma tha Comataidh nan Athchuingean air beachdachadh air fear sa bhliadhna a dh ’fhalbh.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -1996,8 +1996,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action: "Dèan stuth",
                   content_en: "It’s offensive, nonsense, a joke, or an advert.",
                   content_gd: "Tha e oilbheumach, neoni, fealla-dhà no sanas.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -2030,8 +2030,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action: "Dèan stuth",
                   content_en: "It’s offensive, nonsense, a joke, or an advert.",
                   content_gd: "Tha e oilbheumach, neoni, fealla-dhà no sanas.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -2069,8 +2069,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action_en: "Do stuff", action_gd: "Dèan stuth",
                   content_en: "It did not collect enough signatures to be referred to the Petitions Committee.\n\nPetitions need to receive at least 50 signatures before they can be considered in Parliament.",
                   content_gd: "Cha do chruinnich e ainmean-sgrìobhte gu leòr airson an cur gu Comataidh nan Athchuingean.\n\nFeumaidh athchuingean co-dhiù 50 ainm-sgrìobhte fhaighinn mus tèid beachdachadh orra anns a ’Phàrlamaid.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -2103,8 +2103,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                   sponsor: "Suzie", action_en: "Do stuff", action_gd: "Dèan stuth",
                   content_en: "It did not collect enough signatures to be referred to the Petitions Committee.\n\nPetitions need to receive at least 50 signatures before they can be considered in Parliament.",
                   content_gd: "Cha do chruinnich e ainmean-sgrìobhte gu leòr airson an cur gu Comataidh nan Athchuingean.\n\nFeumaidh athchuingean co-dhiù 50 ainm-sgrìobhte fhaighinn mus tèid beachdachadh orra anns a ’Phàrlamaid.",
-                  url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                  url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                  url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                   standards_url_en: "https://petitions.parliament.scot/help#standards",
                   standards_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#standards"
                 }
@@ -2819,8 +2819,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
             personalisation: {
               name: "Charlie",
               action_en: "Do stuff", action_gd: "Dèan stuth",
-              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
               subject_en: "The Petitions committee will be discussing this petition",
               subject_gd: "Bidh comataidh nan Athchuingean a ’deasbad na h-athchuinge seo",
               body_en: "On the 21st July, the Petitions committee will be discussing this petition to see whether to recommend it for a debate in Parliament.",
@@ -2863,8 +2863,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
             personalisation: {
               name: "Charlie",
               action_en: "Do stuff", action_gd: "Dèan stuth",
-              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
               subject_en: "The Petitions committee will be discussing this petition",
               subject_gd: "Bidh comataidh nan Athchuingean a ’deasbad na h-athchuinge seo",
               body_en: "On the 21st July, the Petitions committee will be discussing this petition to see whether to recommend it for a debate in Parliament.",
@@ -2929,8 +2929,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 name: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 subject_en: "The Petitions committee will be discussing this petition",
                 subject_gd: "Bidh comataidh nan Athchuingean a ’deasbad na h-athchuinge seo",
                 body_en: "On the 21st July, the Petitions committee will be discussing this petition to see whether to recommend it for a debate in Parliament.",
@@ -2957,8 +2957,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 name: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 subject_en: "The Petitions committee will be discussing this petition",
                 subject_gd: "Bidh comataidh nan Athchuingean a ’deasbad na h-athchuinge seo",
                 body_en: "On the 21st July, the Petitions committee will be discussing this petition to see whether to recommend it for a debate in Parliament.",
@@ -3005,8 +3005,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 name: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 subject_en: "The Petitions committee will be discussing this petition",
                 subject_gd: "Bidh comataidh nan Athchuingean a ’deasbad na h-athchuinge seo",
                 body_en: "On the 21st July, the Petitions committee will be discussing this petition to see whether to recommend it for a debate in Parliament.",
@@ -3033,8 +3033,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 name: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 subject_en: "The Petitions committee will be discussing this petition",
                 subject_gd: "Bidh comataidh nan Athchuingean a ’deasbad na h-athchuinge seo",
                 body_en: "On the 21st July, the Petitions committee will be discussing this petition to see whether to recommend it for a debate in Parliament.",
@@ -3089,8 +3089,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
             personalisation: {
               name: "Charlie",
               action_en: "Do stuff", action_gd: "Dèan stuth",
-              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
               debate_date_en: "7 July 2020", debate_date_gd: "7 dhen Iuchar 2020",
               unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
               unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
@@ -3132,8 +3132,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
             personalisation: {
               name: "Charlie",
               action_en: "Do stuff", action_gd: "Dèan stuth",
-              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
               debate_date_en: "7 July 2020", debate_date_gd: "7 dhen Iuchar 2020",
               unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
               unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
@@ -3186,8 +3186,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 name: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 debate_date_en: "7 July 2020", debate_date_gd: "7 dhen Iuchar 2020",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
                 unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
@@ -3211,8 +3211,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 name: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 debate_date_en: "7 July 2020", debate_date_gd: "7 dhen Iuchar 2020",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
                 unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
@@ -3258,8 +3258,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 name: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 debate_date_en: "7 July 2020", debate_date_gd: "7 dhen Iuchar 2020",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
                 unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
@@ -3283,8 +3283,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               personalisation: {
                 name: "Suzie",
                 action_en: "Do stuff", action_gd: "Dèan stuth",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 debate_date_en: "7 July 2020", debate_date_gd: "7 dhen Iuchar 2020",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
                 unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
@@ -3339,8 +3339,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               action_en: "Do stuff", action_gd: "Dèan stuth",
               overview_en: "Because it was no longer relevant",
               overview_gd: "Oherwydd nad oedd yn berthnasol mwyach",
-              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
               petitions_committee_url_en: "https://petitions.parliament.scot/help#petitions-committee",
               petitions_committee_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#petitions-committee",
               unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
@@ -3385,8 +3385,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               action_en: "Do stuff", action_gd: "Dèan stuth",
               overview_en: "Because it was no longer relevant",
               overview_gd: "Oherwydd nad oedd yn berthnasol mwyach",
-              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
               petitions_committee_url_en: "https://petitions.parliament.scot/help#petitions-committee",
               petitions_committee_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#petitions-committee",
               unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
@@ -3444,8 +3444,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 action_en: "Do stuff", action_gd: "Dèan stuth",
                 overview_en: "Because it was no longer relevant",
                 overview_gd: "Oherwydd nad oedd yn berthnasol mwyach",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 petitions_committee_url_en: "https://petitions.parliament.scot/help#petitions-committee",
                 petitions_committee_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#petitions-committee",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
@@ -3472,8 +3472,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 action_en: "Do stuff", action_gd: "Dèan stuth",
                 overview_en: "Because it was no longer relevant",
                 overview_gd: "Oherwydd nad oedd yn berthnasol mwyach",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 petitions_committee_url_en: "https://petitions.parliament.scot/help#petitions-committee",
                 petitions_committee_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#petitions-committee",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
@@ -3522,8 +3522,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 action_en: "Do stuff", action_gd: "Dèan stuth",
                 overview_en: "Because it was no longer relevant",
                 overview_gd: "Oherwydd nad oedd yn berthnasol mwyach",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 petitions_committee_url_en: "https://petitions.parliament.scot/help#petitions-committee",
                 petitions_committee_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#petitions-committee",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
@@ -3550,8 +3550,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 action_en: "Do stuff", action_gd: "Dèan stuth",
                 overview_en: "Because it was no longer relevant",
                 overview_gd: "Oherwydd nad oedd yn berthnasol mwyach",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 petitions_committee_url_en: "https://petitions.parliament.scot/help#petitions-committee",
                 petitions_committee_url_gd: "https://athchuingean.parlamaid-alba.scot/cuideachadh#petitions-committee",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
@@ -3619,8 +3619,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               video_url_gd: "https://www.scottishparliament.tv/meeting/public-petitions-committee-january-27-2021",
               debate_pack_url_en: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
               debate_pack_url_gd: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
-              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
               unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
               unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
             }
@@ -3675,8 +3675,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
               video_url_gd: "https://www.scottishparliament.tv/meeting/public-petitions-committee-january-27-2021",
               debate_pack_url_en: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
               debate_pack_url_gd: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
-              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+              petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+              petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
               unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
               unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
             }
@@ -3744,8 +3744,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 video_url_gd: "https://www.scottishparliament.tv/meeting/public-petitions-committee-january-27-2021",
                 debate_pack_url_en: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
                 debate_pack_url_gd: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
                 unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
               }
@@ -3776,8 +3776,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 video_url_gd: "https://www.scottishparliament.tv/meeting/public-petitions-committee-january-27-2021",
                 debate_pack_url_en: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
                 debate_pack_url_gd: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
                 unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
               }
@@ -3836,8 +3836,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 video_url_gd: "https://www.scottishparliament.tv/meeting/public-petitions-committee-january-27-2021",
                 debate_pack_url_en: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
                 debate_pack_url_gd: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
                 unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
               }
@@ -3868,8 +3868,8 @@ RSpec.describe NotifyJob, type: :job, notify: false do
                 video_url_gd: "https://www.scottishparliament.tv/meeting/public-petitions-committee-january-27-2021",
                 debate_pack_url_en: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
                 debate_pack_url_gd: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf",
-                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.id}",
-                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.id}",
+                petition_url_en: "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+                petition_url_gd: "https://athchuingean.parlamaid-alba.scot/athchuingean/#{petition.to_param}",
                 unsubscribe_url_en: "https://petitions.parliament.scot/signatures/#{signature.id}/unsubscribe?token=#{signature.unsubscribe_token}",
                 unsubscribe_url_gd: "https://athchuingean.parlamaid-alba.scot/ainmean-sgriobhte/#{signature.id}/di-chlaradh?token=#{signature.unsubscribe_token}",
               }

--- a/spec/jobs/notify_trending_domain_job_spec.rb
+++ b/spec/jobs/notify_trending_domain_job_spec.rb
@@ -25,8 +25,8 @@ RSpec.describe NotifyTrendingDomainJob, type: :job do
     described_class.perform_now(trending_domain)
 
     message = "32 signatures between 5:00pm and 6:00pm on "
-    message << "<https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}|Do Stuff!> "
-    message << "from <https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}/signatures?q=%40example.com&window=2019-03-31T16%3A00%3A00Z|example.com>"
+    message << "<https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}|Do Stuff!> "
+    message << "from <https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}/signatures?q=%40example.com&window=2019-03-31T16%3A00%3A00Z|example.com>"
 
     body = { payload: { text: message }.to_json }.to_query
 

--- a/spec/jobs/notify_trending_ip_job_spec.rb
+++ b/spec/jobs/notify_trending_ip_job_spec.rb
@@ -37,8 +37,8 @@ RSpec.describe NotifyTrendingIpJob, type: :job do
     described_class.perform_now(trending_ip)
 
     message = "32 signatures between 5:00pm and 6:00pm on "
-    message << "<https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}|Do Stuff!> "
-    message << "from <https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}/signatures?q=127.0.0.1&window=2019-03-31T16%3A00%3A00Z|127.0.0.1>"
+    message << "<https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}|Do Stuff!> "
+    message << "from <https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}/signatures?q=127.0.0.1&window=2019-03-31T16%3A00%3A00Z|127.0.0.1>"
 
     body = { payload: { text: message }.to_json }.to_query
 

--- a/spec/models/paper_petition_spec.rb
+++ b/spec/models/paper_petition_spec.rb
@@ -202,6 +202,7 @@ RSpec.describe PaperPetition, type: :model do
           debate_threshold_reached_at: Time.utc(2020, 4, 30, 11, 0, 0),
           last_signed_at: Time.utc(2020, 4, 30, 11, 0, 0),
           referred_at: Time.utc(2020, 4, 30, 11, 0, 0),
+          pe_number_id: petition.pe_number_id
         )
 
         expect(signature).to have_attributes(

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -784,6 +784,24 @@ RSpec.describe Petition, type: :model do
         expect(Petition.paper).not_to include(closed_petition)
       end
     end
+
+    describe ".find" do
+      let!(:validated_petition) { FactoryBot.create(:validated_petition) }
+      let!(:sponsored_petition) { FactoryBot.create(:sponsored_petition) }
+      let!(:rejected_petition) { FactoryBot.create(:rejected_petition) }
+      let!(:closed_petition) { FactoryBot.create(:closed_petition) }
+      let!(:open_petition) { FactoryBot.create(:open_petition) }
+      let!(:hidden_petition) { FactoryBot.create(:hidden_petition) }
+
+      it "returns the correct petition" do
+        expect(Petition.find(validated_petition.id)).to eq(validated_petition)
+        expect(Petition.find(sponsored_petition.id)).to eq(sponsored_petition)
+        expect(Petition.find(rejected_petition.id)).to eq(rejected_petition)
+        expect(Petition.find(closed_petition.id)).to eq(closed_petition)
+        expect(Petition.find(open_petition.id)).to eq(open_petition)
+        expect(Petition.find(hidden_petition.id)).to eq(hidden_petition)
+      end
+    end
   end
 
   it_behaves_like "a taggable model"

--- a/spec/presenters/petition_csv_presenter_spec.rb
+++ b/spec/presenters/petition_csv_presenter_spec.rb
@@ -19,19 +19,61 @@ RSpec.describe PetitionCSVPresenter do
   describe "#to_csv" do
     subject { described_class.new(petition).to_csv }
 
-    Petition::STATES.each do |state_name|
+    %w[open closed completed].each do |state_name|
       context "with a #{state_name} petition" do
         let!(:petition) { FactoryBot.create "#{state_name}_petition" }
 
-        specify { is_expected.to eq(csvd_petition petition) }
+        specify { is_expected.to eq(csvd_public_petition petition) }
+      end
+    end
+
+    %w[pending validated sponsored flagged hidden rejected].each do |state_name|
+      context "with a #{state_name} petition" do
+        let!(:petition) { FactoryBot.create "#{state_name}_petition" }
+
+        specify { is_expected.to eq(csvd_not_public_petition petition) }
       end
     end
   end
 
-  def csvd_petition(petition)
+  def csvd_not_public_petition(petition)
     [
-      "https://petitions.parliament.scot/petitions/#{petition.id}",
-      "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.id}",
+      "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+      "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}",
+      petition.id,
+      petition.action,
+      petition.background,
+      petition.additional_details,
+      petition.state,
+      petition.creator_name,
+      petition.creator_email,
+      petition.signature_count,
+      petition.rejection_code,
+      petition.rejection_details,
+      petition.debate_date,
+      petition.debate_transcript_url,
+      petition.debate_video_url,
+      petition.debate_pack_url,
+      petition.debate_overview,
+      timestampify(petition.created_at),
+      timestampify(petition.updated_at),
+      timestampify(petition.open_at),
+      timestampify(petition.closed_at),
+      datestampify(petition.scheduled_debate_date),
+      timestampify(petition.referral_threshold_reached_at),
+      timestampify(petition.debate_threshold_reached_at),
+      timestampify(petition.rejected_at),
+      timestampify(petition.debate_outcome_at),
+      timestampify(petition.moderation_threshold_reached_at),
+      timestampify(petition.completed_at),
+      petition.note.try(:details)
+    ].join(",") + "\n"
+  end
+
+  def csvd_public_petition(petition)
+    [
+      "https://petitions.parliament.scot/petitions/#{petition.to_param}",
+      "https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}",
       petition.id,
       petition.action,
       petition.background,

--- a/spec/requests/cache_control_header_spec.rb
+++ b/spec/requests/cache_control_header_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe 'Cache-Control headers', type: :request do
     let!(:petition) { FactoryBot.create(:open_petition) }
 
     before do
-      get "/petitions/#{petition.id}"
+      get "/petitions/#{petition.to_param}"
     end
 
     it "doesn't change the cache control headers" do
@@ -45,7 +45,7 @@ RSpec.describe 'Cache-Control headers', type: :request do
     let!(:petition) { FactoryBot.create(:pending_petition) }
 
     before do
-      get "/petitions/#{petition.id}/sponsors/new?token=#{petition.sponsor_token}"
+      get "/petitions/#{petition.to_param}/sponsors/new?token=#{petition.sponsor_token}"
     end
 
     it "changes the cache control headers to 'no-store'" do
@@ -58,7 +58,7 @@ RSpec.describe 'Cache-Control headers', type: :request do
     let!(:petition) { FactoryBot.create(:open_petition) }
 
     before do
-      get "/petitions/#{petition.id}/signatures/new"
+      get "/petitions/#{petition.to_param}/signatures/new"
     end
 
     it "changes the cache control headers to 'no-store'" do

--- a/spec/requests/disallowed_format_spec.rb
+++ b/spec/requests/disallowed_format_spec.rb
@@ -209,7 +209,7 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
   end
 
   context 'the petitions show url' do
-    let(:url) { "/petitions/#{petition.id}" }
+    let(:url) { "/petitions/#{petition.to_param}" }
     let(:petition) { FactoryBot.create(:open_petition) }
     let(:params) { {} }
 
@@ -224,7 +224,7 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
   end
 
   context 'the petitions/gathering-support url' do
-    let(:url) { "/petitions/#{petition.id}/gathering-support" }
+    let(:url) { "/petitions/#{petition.to_param}/gathering-support" }
     let(:petition) { FactoryBot.create(:validated_petition) }
     let(:params) { {} }
 
@@ -232,7 +232,7 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
   end
 
   context 'the petitions/moderation-info url' do
-    let(:url) { "/petitions/#{petition.id}/moderation-info" }
+    let(:url) { "/petitions/#{petition.to_param}/moderation-info" }
     let(:petition) { FactoryBot.create(:sponsored_petition) }
     let(:params) { {} }
 
@@ -240,7 +240,7 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
   end
 
   context 'the petitions/sponsors/new url' do
-    let(:url) { "/petitions/#{petition.id}/sponsors/new" }
+    let(:url) { "/petitions/#{petition.to_param}/sponsors/new" }
     let(:petition) { FactoryBot.create(:pending_petition) }
     let(:params) {
       {
@@ -252,7 +252,7 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
   end
 
   context 'the petitions/sponsors/thank-you url' do
-    let(:url) { "/petitions/#{petition.id}/sponsors/thank-you" }
+    let(:url) { "/petitions/#{petition.to_param}/sponsors/thank-you" }
     let(:petition) { FactoryBot.create(:pending_petition) }
     let(:params) {
       {
@@ -277,7 +277,7 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
   end
 
   context 'the petitions/signatures/new url' do
-    let(:url) { "/petitions/#{petition.id}/signatures/new" }
+    let(:url) { "/petitions/#{petition.to_param}/signatures/new" }
     let(:petition) { FactoryBot.create(:open_petition) }
     let(:params) { {} }
 
@@ -285,7 +285,7 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
   end
 
   context 'the petitions/signatures/thank-you url' do
-    let(:url) { "/petitions/#{petition.id}/signatures/thank-you" }
+    let(:url) { "/petitions/#{petition.to_param}/signatures/thank-you" }
     let(:petition) { FactoryBot.create(:open_petition) }
     let(:params) { {} }
 
@@ -388,13 +388,13 @@ RSpec.describe 'Requests for pages when we do not support the format on that pag
   end
 
   context 'a failed post to signatures/new' do
-    let(:url) { "/petitions/#{petition.id}/signatures/new" }
+    let(:url) { "/petitions/#{petition.to_param}/signatures/new" }
     let(:petition) { FactoryBot.create(:open_petition) }
     let(:params) {
       {
         'stage' => 'replay-email',
         'move' => 'next',
-        'petition_id' => "#{petition.id}",
+        'petition_id' => "#{petition.to_param}",
         'signature' => {
           'name' => 'John Mcenroe', 'email' => 'john@example.com',
           'postcode' => 'SE3 4LL', 'location_code' => 'GB'

--- a/spec/requests/invalid_ids_spec.rb
+++ b/spec/requests/invalid_ids_spec.rb
@@ -3,58 +3,58 @@ require 'rails_helper'
 RSpec.describe "invalid ids", type: :request, show_exceptions: true, csrf: false do
   context "when on the English website" do
     describe "GET /petitions/:id" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/petitions/not-a-number"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /petitions/:id/count.json" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/petitions/not-a-number/count.json"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /petitions/:id/gathering-support" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/petitions/not-a-number/gathering-support"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /petitions/:id/moderation-info" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/petitions/not-a-number/moderation-info"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /petitions/:petition_id/sponsors/new" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/petitions/not-a-number/sponsors/new"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "POST /petitions/:petition_id/sponsors/new" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         post "/petitions/not-a-number/sponsors/new"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "POST /petitions/:petition_id/sponsors" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         post "/petitions/not-a-number/sponsors"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /petitions/:petition_id/sponsors/thank-you" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/petitions/not-a-number/sponsors/thank-you"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -73,30 +73,30 @@ RSpec.describe "invalid ids", type: :request, show_exceptions: true, csrf: false
     end
 
     describe "GET /petitions/:petition_id/signatures/new" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/petitions/not-a-number/signatures/new"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "POST /petitions/:petition_id/signatures/new" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         post "/petitions/not-a-number/signatures/new"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "POST /petitions/:petition_id/signatures" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         post "/petitions/not-a-number/signatures"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /petitions/:petition_id/signatures/thank-you" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/petitions/not-a-number/signatures/thank-you"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -124,58 +124,58 @@ RSpec.describe "invalid ids", type: :request, show_exceptions: true, csrf: false
 
   context "when on the Gaelic website", gaelic: true do
     describe "GET /athchuingean/:id" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/athchuingean/no-aireamh"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /athchuingean/:id/cunnt.json" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/athchuingean/no-aireamh/cunnt.json"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /athchuingean/:id/cruinneachadh-taic" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/athchuingean/no-aireamh/cruinneachadh-taic"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /athchuingean/:id/fiosrachadh-measaidh" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/athchuingean/no-aireamh/fiosrachadh-measaidh"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /athchuingean/:petition_id/luchd-taic/ur" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/athchuingean/no-aireamh/luchd-taic/ur"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "POST /athchuingean/:petition_id/luchd-taic/ur" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         post "/athchuingean/no-aireamh/luchd-taic/ur"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "POST /athchuingean/:petition_id/luchd-taic" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         post "/athchuingean/no-aireamh/luchd-taic"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /athchuingean/:petition_id/luchd-taic/tapadh-leibh" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/athchuingean/no-aireamh/luchd-taic/tapadh-leibh"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
@@ -194,30 +194,30 @@ RSpec.describe "invalid ids", type: :request, show_exceptions: true, csrf: false
     end
 
     describe "GET /athchuingean/:petition_id/ainmean-sgriobhte/ur" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/athchuingean/no-aireamh/ainmean-sgriobhte/ur"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "POST /athchuingean/:petition_id/ainmean-sgriobhte/ur" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         post "/athchuingean/no-aireamh/ainmean-sgriobhte/ur"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "POST /athchuingean/:petition_id/ainmean-sgriobhte" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         post "/athchuingean/no-aireamh/ainmean-sgriobhte"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 
     describe "GET /athchuingean/:petition_id/ainmean-sgriobhte/tapadh-leibh" do
-      it "returns a 400 Bad Request" do
+      it "returns a 404 Not Found" do
         get "/athchuingean/no-aireamh/ainmean-sgriobhte/tapadh-leibh"
-        expect(response).to have_http_status(:bad_request)
+        expect(response).to have_http_status(:not_found)
       end
     end
 

--- a/spec/requests/missing_tokens_spec.rb
+++ b/spec/requests/missing_tokens_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe "missing a 'token'", type: :request, show_exceptions: true do
     end
 
     it "redirects to the petition page" do
-      expect(response).to redirect_to("/petitions/#{petition.id}")
+      expect(response).to redirect_to("/petitions/#{petition.to_param}")
     end
   end
 

--- a/spec/requests/petition_show_spec.rb
+++ b/spec/requests/petition_show_spec.rb
@@ -10,12 +10,12 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
 
   describe "format" do
     it "responds to JSON" do
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
     end
 
     it "sets CORS headers" do
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
 
       expect(response).to be_successful
       expect(access_control_allow_origin).to eq('*')
@@ -24,7 +24,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
     end
 
     it "does not respond to XML" do
-      get "/petitions/#{petition.id}.xml"
+      get "/petitions/#{petition.to_param}.xml"
       expect(response.status).to eq(406)
     end
   end
@@ -33,16 +33,16 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
     let(:links) { json["links"] }
 
     it "returns a link to itself" do
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
 
       expect(response).to be_successful
-      expect(links).to include("self" => "https://petitions.parliament.scot/petitions/#{petition.id}.json")
+      expect(links).to include("self" => "https://petitions.parliament.scot/petitions/#{petition.to_param}.json")
     end
   end
 
   describe "data" do
     it "returns the petition with the expected fields" do
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -63,7 +63,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
     it "returns the closed_at timestamp if the petition is closed" do
       petition = FactoryBot.create :closed_petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -77,7 +77,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
     it "returns the completed_at timestamp date if the petition is completed" do
       petition = FactoryBot.create :completed_petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -91,7 +91,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
     it "returns the archived_at timestamp date if the petition is archived" do
       petition = FactoryBot.create :archived_petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -105,7 +105,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
     it "returns the submitted_on date if the petition was submitted on paper" do
       petition = FactoryBot.create :paper_petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -119,7 +119,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
     it "doesn't include the rejection section for non-rejected petitions" do
       petition = FactoryBot.create :open_petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -136,7 +136,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
           rejection_code: "duplicate",
           rejection_details: "This is a duplication of another petition"
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -157,7 +157,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
           referral_threshold_reached_at: 1.weeks.ago,
           debate_threshold_reached_at: 1.day.ago
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -172,7 +172,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
     it "includes the date and time at which the petition was referred" do
       petition = FactoryBot.create :referred_petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -185,7 +185,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
     it "includes the date when a petition is scheduled for a debate" do
       petition = FactoryBot.create :scheduled_debate_petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -204,7 +204,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
           video_url: "https://www.scottishparliament.tv/meeting/public-petitions-committee-january-27-2021",
           debate_pack_url: "http://www.parliament.scot/S5_PublicPetitionsCommittee/Reports/PPCS052020R2.pdf"
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -228,7 +228,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
         FactoryBot.create :open_petition,
           topics: [topic.id]
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -247,7 +247,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
       FactoryBot.create :constituency_petition_journal, constituency_id: "S16000147", signature_count: 123, petition: petition
       FactoryBot.create :constituency_petition_journal, constituency_id: "S16000096", signature_count: 456, petition: petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -277,7 +277,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
       FactoryBot.create :constituency_petition_journal, constituency_id: "S16000147", signature_count: 123, petition: petition
       FactoryBot.create :constituency_petition_journal, constituency_id: "S16000096", signature_count: 456, petition: petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes.keys).not_to include("signatures_by_constituency")
@@ -289,7 +289,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
       FactoryBot.create :country_petition_journal, location_code: "GB-SCT", signature_count: 123456, petition: petition
       FactoryBot.create :country_petition_journal, location_code: "FR", signature_count: 789, petition: petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -316,7 +316,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
       FactoryBot.create :country_petition_journal, location_code: "GB-SCT", signature_count: 123456, petition: petition
       FactoryBot.create :country_petition_journal, location_code: "FR", signature_count: 789, petition: petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes.keys).not_to include("signatures_by_country")
@@ -331,7 +331,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
       FactoryBot.create :constituency_petition_journal, constituency_id: "S16000147", signature_count: 123, petition: petition
       FactoryBot.create :constituency_petition_journal, constituency_id: "S16000096", signature_count: 456, petition: petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes).to match(
@@ -361,7 +361,7 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
       FactoryBot.create :constituency_petition_journal, constituency_id: "S16000147", signature_count: 123, petition: petition
       FactoryBot.create :constituency_petition_journal, constituency_id: "S16000096", signature_count: 456, petition: petition
 
-      get "/petitions/#{petition.id}.json"
+      get "/petitions/#{petition.to_param}.json"
       expect(response).to be_successful
 
       expect(attributes.keys).not_to include("signatures_by_region")

--- a/spec/requests/petitions_list_spec.rb
+++ b/spec/requests/petitions_list_spec.rb
@@ -134,7 +134,7 @@ RSpec.describe "API request to list petitions", type: :request, show_exceptions:
         a_collection_containing_exactly(
           a_hash_including(
             "links" => a_hash_including(
-              "self" => "https://petitions.parliament.scot/petitions/#{petition.id}.json"
+              "self" => "https://petitions.parliament.scot/petitions/#{petition.to_param}.json"
             )
           )
         )
@@ -261,4 +261,3 @@ RSpec.describe "API request to list petitions", type: :request, show_exceptions:
     end
   end
 end
-

--- a/spec/requests/session_cookie_spec.rb
+++ b/spec/requests/session_cookie_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'session cookie', type: :request, show_exceptions: true do
 
   before do
     petition = FactoryBot.create(:open_petition)
-    get "/petitions/#{petition.id}/signatures/new"
+    get "/petitions/#{petition.to_param}/signatures/new"
   end
 
   around do |example|

--- a/spec/requests/unknown_format_spec.rb
+++ b/spec/requests/unknown_format_spec.rb
@@ -2,10 +2,10 @@ require 'rails_helper'
 
 RSpec.describe 'Requests for an unknown format', type: :request, show_exceptions: true do
   before do
-    get "/petitions/100001.please"
+    get "/petitions/PE100001.please"
   end
 
   it "redirect to the path without the extension" do
-    expect(response).to redirect_to('/petitions/100001')
+    expect(response).to redirect_to('/petitions/PE100001')
   end
 end

--- a/spec/routing/petitions_spec.rb
+++ b/spec/routing/petitions_spec.rb
@@ -26,11 +26,6 @@ RSpec.describe "routes for petitions", type: :routes do
       expect(post("/petitions")).not_to be_routable
     end
 
-    it "routes GET /petitions/:id to petitions#show" do
-      expect(get("/petitions/1")).to route_to(controller: "petitions", action: "show", id: "1")
-      expect(petition_path("1")).to eq("/petitions/1")
-    end
-
     it "doesn't route GET /petitions/:id/edit" do
       expect(patch("/petitions/1/edit")).not_to be_routable
     end
@@ -58,18 +53,32 @@ RSpec.describe "routes for petitions", type: :routes do
     end
 
     it "routes GET /petitions/:id/count to petitions#count" do
-      expect(get("/petitions/1/count")).to route_to(controller: "petitions", action: "count", id: "1")
-      expect(count_petition_path("1")).to eq("/petitions/1/count")
+      expect(get("/petitions/PE0001/count")).to route_to(controller: "petitions", action: "count", id: "PE0001")
+      expect(count_petition_path("PE0001")).to eq("/petitions/PE0001/count")
     end
 
     it "routes GET /petitions/:id/gathering-support to petitions#gathering_support" do
-      expect(get("/petitions/1/gathering-support")).to route_to(controller: "petitions", action: "gathering_support", id: "1")
-      expect(gathering_support_petition_path("1")).to eq("/petitions/1/gathering-support")
+      expect(get("/petitions/PE0001/gathering-support")).to route_to(controller: "petitions", action: "gathering_support", id: "PE0001")
+      expect(gathering_support_petition_path("PE0001")).to eq("/petitions/PE0001/gathering-support")
     end
 
     it "routes GET /petitions/:id/moderation-info to petitions#moderation_info" do
-      expect(get("/petitions/1/moderation-info")).to route_to(controller: "petitions", action: "moderation_info", id: "1")
-      expect(moderation_info_petition_path("1")).to eq("/petitions/1/moderation-info")
+      expect(get("/petitions/PE0001/moderation-info")).to route_to(controller: "petitions", action: "moderation_info", id: "PE0001")
+      expect(moderation_info_petition_path("PE0001")).to eq("/petitions/PE0001/moderation-info")
+    end
+
+    context "when petitions do not need to collect sponsors to be submitted for moderation" do
+      before do
+        Site.instance.update!(
+          minimum_number_of_sponsors: 0,
+          threshold_for_moderation: 0
+        )
+      end
+
+      it "routes GET /petitions/PE:id/count to petitions#count" do
+        expect(get("/petitions/PE0001/count")).to route_to(controller: "petitions", action: "count", id: "PE0001")
+        expect(count_petition_path("PE0001")).to eq("/petitions/PE0001/count")
+      end
     end
 
     describe "redirects" do
@@ -86,7 +95,7 @@ RSpec.describe "routes for petitions", type: :routes do
       end
 
       it "GET /athchuingean/:id" do
-        expect(get("/athchuingean/1")).to redirect_to("/petitions/1", 308)
+        expect(get("/athchuingean/PE0001")).to redirect_to("/petitions/PE0001", 308)
       end
 
       it "GET /athchuingean/thoir-suil" do
@@ -98,7 +107,7 @@ RSpec.describe "routes for petitions", type: :routes do
       end
 
       it "GET /athchuingean/:id/cunnt" do
-        expect(get("/athchuingean/1/cunnt")).to redirect_to("/petitions/1/count", 308)
+        expect(get("/athchuingean/PE0001/cunnt")).to redirect_to("/petitions/PE0001/count", 308)
       end
 
       it "GET /athchuingean/tapadh-leibh" do
@@ -106,11 +115,11 @@ RSpec.describe "routes for petitions", type: :routes do
       end
 
       it "GET /athchuingean/:id/cruinneachadh-taic" do
-        expect(get("/athchuingean/1/cruinneachadh-taic")).to redirect_to("/petitions/1/gathering-support", 308)
+        expect(get("/athchuingean/PE0001/cruinneachadh-taic")).to redirect_to("/petitions/PE0001/gathering-support", 308)
       end
 
       it "GET /athchuingean/:id/fiosrachadh-measaidh" do
-        expect(get("/athchuingean/1/fiosrachadh-measaidh")).to redirect_to("/petitions/1/moderation-info", 308)
+        expect(get("/athchuingean/PE0001/fiosrachadh-measaidh")).to redirect_to("/petitions/PE0001/moderation-info", 308)
       end
     end
   end
@@ -141,8 +150,8 @@ RSpec.describe "routes for petitions", type: :routes do
     end
 
     it "routes GET /athchuingean/:id to petitions#show" do
-      expect(get("/athchuingean/1")).to route_to(controller: "petitions", action: "show", id: "1")
-      expect(petition_path("1")).to eq("/athchuingean/1")
+      expect(get("/athchuingean/PE0001")).to route_to(controller: "petitions", action: "show", id: "PE0001")
+      expect(petition_path("PE0001")).to eq("/athchuingean/PE0001")
     end
 
     it "doesn't route GET /athchuingean/:id/deasaich" do
@@ -172,18 +181,18 @@ RSpec.describe "routes for petitions", type: :routes do
     end
 
     it "routes GET /athchuingean/:id/cunnt to petitions#count" do
-      expect(get("/athchuingean/1/cunnt")).to route_to(controller: "petitions", action: "count", id: "1")
-      expect(count_petition_path("1")).to eq("/athchuingean/1/cunnt")
+      expect(get("/athchuingean/PE0001/cunnt")).to route_to(controller: "petitions", action: "count", id: "PE0001")
+      expect(count_petition_path("PE0001")).to eq("/athchuingean/PE0001/cunnt")
     end
 
     it "routes GET /athchuingean/:id/cruinneachadh-taic to petitions#gathering_support" do
-      expect(get("/athchuingean/1/cruinneachadh-taic")).to route_to(controller: "petitions", action: "gathering_support", id: "1")
-      expect(gathering_support_petition_path("1")).to eq("/athchuingean/1/cruinneachadh-taic")
+      expect(get("/athchuingean/PE0001/cruinneachadh-taic")).to route_to(controller: "petitions", action: "gathering_support", id: "PE0001")
+      expect(gathering_support_petition_path("PE0001")).to eq("/athchuingean/PE0001/cruinneachadh-taic")
     end
 
     it "routes GET /athchuingean/:id/fiosrachadh-measaidh to petitions#moderation_info" do
-      expect(get("/athchuingean/1/fiosrachadh-measaidh")).to route_to(controller: "petitions", action: "moderation_info", id: "1")
-      expect(moderation_info_petition_path("1")).to eq("/athchuingean/1/fiosrachadh-measaidh")
+      expect(get("/athchuingean/PE0001/fiosrachadh-measaidh")).to route_to(controller: "petitions", action: "moderation_info", id: "PE0001")
+      expect(moderation_info_petition_path("PE0001")).to eq("/athchuingean/PE0001/fiosrachadh-measaidh")
     end
 
     describe "redirects" do
@@ -200,7 +209,7 @@ RSpec.describe "routes for petitions", type: :routes do
       end
 
       it "GET /petitions/:id" do
-        expect(get("/petitions/1")).to redirect_to("/athchuingean/1", 308)
+        expect(get("/petitions/PE0001")).to redirect_to("/athchuingean/PE0001", 308)
       end
 
       it "GET /petitions/check" do
@@ -212,7 +221,7 @@ RSpec.describe "routes for petitions", type: :routes do
       end
 
       it "GET /petitions/:id/count" do
-        expect(get("/petitions/1/count")).to redirect_to("/athchuingean/1/cunnt", 308)
+        expect(get("/petitions/PE0001/count")).to redirect_to("/athchuingean/PE0001/cunnt", 308)
       end
 
       it "GET /petitions/thank-you" do
@@ -220,11 +229,11 @@ RSpec.describe "routes for petitions", type: :routes do
       end
 
       it "GET /petitions/:id/gathering-support" do
-        expect(get("/petitions/1/gathering-support")).to redirect_to("/athchuingean/1/cruinneachadh-taic", 308)
+        expect(get("/petitions/PE0001/gathering-support")).to redirect_to("/athchuingean/PE0001/cruinneachadh-taic", 308)
       end
 
       it "GET /petitions/:id/moderation-info" do
-        expect(get("/petitions/1/moderation-info")).to redirect_to("/athchuingean/1/fiosrachadh-measaidh", 308)
+        expect(get("/petitions/PE0001/moderation-info")).to redirect_to("/athchuingean/PE0001/fiosrachadh-measaidh", 308)
       end
     end
   end


### PR DESCRIPTION
Scottish Parliament Petitions Committee assigns PP numbers (only visible to admins) and PE numbers (visible to public) to petitions. This implements them in the system

https://trello.com/c/oaIwDSPg/51-as-a-petitions-clerk-i-need-to-know-the-pp-number-for-a-petition-and-as-well-as-pe-number-once-petition-has-been-published-pp-nu