### PR TITLE
Make signature counting more robust

### DIFF
--- a/app/jobs/concerns/session_advisory_lock.rb
+++ b/app/jobs/concerns/session_advisory_lock.rb
@@ -1,0 +1,36 @@
+require 'zlib'
+
+module SessionAdvisoryLock
+  extend ActiveSupport::Concern
+
+  class LockFailedError < RuntimeError; end
+
+  included do
+    delegate :connection, to: :"ActiveRecord::Base"
+    delegate :select_value, to: :connection
+
+    lock_id = Zlib.crc32(self.name)
+    lock_sql = "SELECT pg_try_advisory_lock(#{lock_id})"
+    unlock_sql = "SELECT pg_advisory_unlock(#{lock_id})"
+
+    define_method :get_advisory_lock do
+      select_value(lock_sql)
+    end
+
+    define_method :release_advisory_lock do
+      select_value(unlock_sql)
+    end
+  end
+
+  private
+
+  def with_lock
+    unless locked = get_advisory_lock
+      raise LockFailedError, "Unable to obtain advisory lock, check for concurrent #{self.class.name} jobs"
+    end
+
+    yield
+  ensure
+    release_advisory_lock if locked
+  end
+end

--- a/config/initializers/delayed_job_config.rb
+++ b/config/initializers/delayed_job_config.rb
@@ -2,51 +2,18 @@ Delayed::Worker.max_attempts = 15
 Delayed::Worker.max_run_time = 6.hours
 Delayed::Worker.default_priority = 100
 
-require 'active_job/queue_adapters/delayed_job_adapter'
-
-# We patch in the display_name method to the Delayed Job queue adapter
-# so that all the jobs aren't aggregated under one name in AppSignal.
-module ActiveJob
-  module QueueAdapters
-    class DelayedJobAdapter
-      class JobWrapper
-        def display_name
-          if job_data['job_class'] == 'ActionMailer::DeliveryJob'
-            "#{job_data['arguments'][0]}##{job_data['arguments'][1]}"
-          else
-            "#{job_data['job_class']}#perform"
-          end
-        end
-      end
-    end
-  end
-end
-
-# Override the default after_fork method on Delayed::Backend::ActiveRecord::Job
-# to restart the Appsignal agent when the worker is forked.
-module Delayed
-  module Backend
-    module ActiveRecord
-      class Job < ::ActiveRecord::Base
-        def self.after_fork
-          # Worker specific setup for Rails 4.1+
-          # See: https://devcenter.heroku.com/articles/deploying-rails-applications-with-the-puma-web-server#on-worker-boot
-          ::ActiveRecord::Base.establish_connection
-
-          # Let AppSignal know that a worker process has been forked
-          ::Appsignal.forked if defined?(::Appsignal) && ::Appsignal.config.active?
-        end
-      end
-    end
-  end
-end
-
 # Add a before_save callback to set the priority based on the queue name
 module Delayed
   module Backend
     module ActiveRecord
       class Job < ::ActiveRecord::Base
-        QUEUE_PRIORITIES = { "highest_priority" => 0, "high_priority" => 10, "low_priority" => 50 }
+        QUEUE_PRIORITIES = {
+          "counter"          => 0,
+          "highest_priority" => 0,
+          "high_priority"    => 10,
+          "low_priority"     => 50
+        }
+
         QUEUE_PRIORITIES.default = 25
 
         before_create do


### PR DESCRIPTION
When the RDS service did a security update the inability of delayed_job to recover from connection errors led to two instances of the counting job being enqueued as there's a task that runs every 15 minutes to ensure it's running. When delayed_job was restarted after log rotation this unlocked the original job and resulted in both jobs being processed and signatures being double counted for a short period.

This commit tries to prevent this from reoccurring in the future by using PostgreSQL advisory locks to ensure that two jobs can't run concurrently in the same way Active Record uses them to prevent migrations from being run concurrently. Given this restriction we can put the count job onto it's own queue and if we detect there is more than
one job on the queue then skip processing and don't requeue.

We also change the job to send exceptions to Appsignal as the problem went unnoticed for a couple of hours - it's not expected that this job will be continually raising errors so anything occurring should be addressed as a matter of priority.