### PR TITLE
Remove obsolete generator primary key config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -67,11 +67,6 @@ module ScotsPets
       %r[\A/petitions/\d+/count.json\z], %q[/admin/status.json], %q[/ping]
     ]
 
-    # Generate integer primary keys
-    config.generators do |generator|
-      generator.orm :active_record, primary_key_type: :serial
-    end
-
     # Using a sass css compressor causes a scss file to be processed twice (once
     # to build, once to compress) which breaks the usage of "unquote" to use
     # CSS that has same function names as SCSS such as max


### PR DESCRIPTION
Now that primary keys have been changed to bigints we no longer need to default the migration generator to use the old :serial format.