### PR TITLE
Redirect to new thank you

### DIFF
--- a/app/controllers/petitioners_controller.rb
+++ b/app/controllers/petitioners_controller.rb
@@ -5,7 +5,13 @@ class PetitionersController < SponsorsController
     @petition.validate_creator!
     @petition.increment_signature_count!
 
-    redirect_to moderation_info_petition_url(@petition)
+    redirect_to thank_you_petitioner_url(@signature)
+  end
+
+  def thank_you
+    respond_to do |format|
+      format.html
+    end
   end
 
   private
@@ -18,6 +24,11 @@ class PetitionersController < SponsorsController
 
   def retrieve_signature
     @signature = Signature.find(signature_id)
+    @petition = @signature.petition
+  end
+
+  def retrieve_petition
+    @signature = Signature.find(params[:id])
     @petition = @signature.petition
   end
 end

--- a/app/views/petitioners/thank_you.html.erb
+++ b/app/views/petitioners/thank_you.html.erb
@@ -1,0 +1,5 @@
+<h1><%= t(:"ui.petitions.moderation_info.heading") %></h1>
+
+<p><%= t(:"ui.petitions.moderation_info.checking_standards_html", standards_link: petition_standards_link) %></p>
+
+<p><%= t(:"ui.petitions.moderation_info.try_again_later") %></p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Rails.application.routes.draw do
 
     scope '/petitioners', controller: 'petitioners' do
       get '/:id/verify', action: 'verify', as: :verify_petitioner
+      get '/:id/thank-you', action: 'thank_you', as: :thank_you_petitioner
     end
 
     scope '/sponsors', controller: 'sponsors' do

--- a/spec/controllers/petitioners_controller_spec.rb
+++ b/spec/controllers/petitioners_controller_spec.rb
@@ -48,8 +48,8 @@ RSpec.describe PetitionersController, type: :controller do
         expect(petition.reload.state).to eq("sponsored")
       end
 
-      it "redirects to the moderation info page" do
-        expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+      it "redirects to the thank you page" do
+        expect(response).to redirect_to("/petitioners/#{signature.id}/thank-you")
       end
     end
 
@@ -62,8 +62,8 @@ RSpec.describe PetitionersController, type: :controller do
           get :verify, params: { id: signature.id, token: signature.perishable_token }
         end
 
-        it "redirects to the moderation info page" do
-          expect(response).to redirect_to("/petitions/#{petition.id}/moderation-info")
+        it "redirects to the thank you page" do
+          expect(response).to redirect_to("/petitioners/#{signature.id}/thank-you")
         end
       end
     end


### PR DESCRIPTION
Instead of using the signatures/thank-you, the petitioners controller now redirects to its own thank-you url