### PR TITLE
Add a staging environment

### DIFF
--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -1,0 +1,52 @@
+name: Deploy to Staging
+
+on:
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    environment:
+      name: scottish-petitions-staging
+      url: https://staging.scotpets.net/
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Setup ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: 2.6
+
+    - name: Install postgres client
+      run: |
+        sudo apt-get -yqq install libpq-dev
+
+    - name: Setup gem cache
+      uses: actions/cache@v1
+      with:
+        path: vendor/bundle
+        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-gems-
+
+    - name: Install gems
+      run: |
+        gem install bundler -v 1.17.3
+        bundle install --jobs 4 --retry 3 --path vendor/bundle
+
+    - name: Configure AWS credentials
+      uses: aws-actions/configure-aws-credentials@v1
+      with:
+        aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        aws-region: eu-west-2
+
+    - name: Deploy application
+      env:
+        APPSIGNAL_APP_NAME: scottish-petitions-staging
+        APPSIGNAL_PUSH_API_KEY: ${{ secrets.APPSIGNAL_PUSH_API_KEY }}
+      run: |
+        bundle exec rake deploy:staging

--- a/lib/tasks/deploy.rake
+++ b/lib/tasks/deploy.rake
@@ -6,6 +6,11 @@ namespace :deploy do
     PackageBuilder.build!
   end
 
+  desc "Build and deploy the website to the staging stack"
+  task :staging do
+    PackageBuilder.deploy!(:staging)
+  end
+
   desc "Build and deploy the website to the preview stack"
   task :preview do
     PackageBuilder.deploy!(:preview)


### PR DESCRIPTION
A staging environment will allow for more experimental changes such as removing Notify to be tested without breaking the preview environment which will needed to test out content changes in the next sprint.