### PR TITLE
Add platform specific versions of nokogiri

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -251,6 +251,12 @@ GEM
     nokogiri (1.11.1)
       mini_portile2 (~> 2.5.0)
       racc (~> 1.4)
+    nokogiri (1.11.1-arm64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.1-x86_64-darwin)
+      racc (~> 1.4)
+    nokogiri (1.11.1-x86_64-linux)
+      racc (~> 1.4)
     notiffany (0.1.3)
       nenv (~> 0.1)
       shellany (~> 0.0)
@@ -393,7 +399,10 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  arm64-darwin
   ruby
+  x86_64-darwin
+  x86_64-linux
 
 DEPENDENCIES
   appsignal

--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -231,7 +231,8 @@ class PackageBuilder
     args = %w[bundle package --all --all-platforms --no-install]
 
     info "Packaging gems ..."
-    Bundler.with_clean_env do
+
+    with_build_env do
       Kernel.system(*args)
     end
   end
@@ -481,5 +482,19 @@ class PackageBuilder
 
   def script_file_path(name)
     File.expand_path("../package_builder/scripts/#{name}.sh", __FILE__)
+  end
+
+  def with_build_env
+    # Force specific_platform to be true
+    # https://github.com/rubygems/bundler/issues/5863
+    env = Bundler.original_env
+    env["BUNDLE_SPECIFIC_PLATFORM"] = "true"
+
+    backup = ENV.to_hash
+    ENV.replace(env)
+
+    yield
+  ensure
+    ENV.replace(backup)
   end
 end


### PR DESCRIPTION
As of v1.11.0, nokogiri started shipping native gems but to get this to work with developing on a Mac (x86 or ARM) we need to add the plaforms to the lockfile and tweak our package building to include the linux version which our servers need. This makes our package about 15MB larger but ours is relatively small any way (45MB after this change).