### PR TITLE
Add confirmation for privacy notice

### DIFF
--- a/app/assets/stylesheets/frontend/forms.scss
+++ b/app/assets/stylesheets/frontend/forms.scss
@@ -359,6 +359,18 @@ select, input[type=text] {
     }
   }
 
+  .privacy-notice {
+    padding: 0px 12px 9px 12px;
+
+    @include media(tablet) {
+      padding-top: 0px;
+    }
+  }
+
+  .error-message {
+    padding-left: 12px;
+  }
+
   .form-hint {
     float: left;
     clear: left;

--- a/app/controllers/admin/signatures_controller.rb
+++ b/app/controllers/admin/signatures_controller.rb
@@ -164,11 +164,11 @@ class Admin::SignaturesController < Admin::AdminController
   end
 
   def signature_params_for_create
-    signature_params.merge(ip_address: request.remote_ip)
+    signature_params.merge(ip_address: request.remote_ip, privacy_notice: "1")
   end
 
   def signature_attributes
-    %i[name postcode location_code autogenerate_email]
+    %i[name postcode location_code autogenerate_email privacy_notice]
   end
 
   def search_params

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -209,6 +209,6 @@ class SignaturesController < LocalizedController
   end
 
   def signature_attributes
-    %i[name email postcode location_code notify_by_email autocorrect_domain]
+    %i[name email postcode location_code notify_by_email autocorrect_domain privacy_notice]
   end
 end

--- a/app/models/paper_petition.rb
+++ b/app/models/paper_petition.rb
@@ -161,7 +161,8 @@ class PaperPetition
   def signature_params
     {
       name: name, email: email, postcode: postcode,
-      location_code: location_code, locale: locale
+      location_code: location_code, locale: locale,
+      privacy_notice: "1"
     }
   end
 

--- a/app/models/petition_creator.rb
+++ b/app/models/petition_creator.rb
@@ -9,10 +9,10 @@ class PetitionCreator
   STAGES = %w[petition replay_petition signature_collection creator replay_email]
 
   PETITION_PARAMS     = [:action, :background, :additional_details, :collect_signatures]
-  SIGNATURE_PARAMS    = [:name, :email, :phone_number, :address, :postcode, :location_code]
+  SIGNATURE_PARAMS    = [:name, :email, :phone_number, :address, :postcode, :location_code, :privacy_notice]
   PERMITTED_PARAMS    = [:q, :stage, :move_back, :move_next, petition_creator: PETITION_PARAMS + SIGNATURE_PARAMS]
 
-  attr_reader :params, :errors, :request
+  attr_reader :params, :errors, :request, :privacy_notice
 
   def initialize(params, request)
     @params = params.permit(*PERMITTED_PARAMS)
@@ -64,6 +64,7 @@ class PetitionCreator
           c.constituency_id = constituency_id
           c.notify_by_email = true
           c.ip_address = request.remote_ip
+          c.privacy_notice = privacy_notice
         end
       end
 
@@ -143,6 +144,10 @@ class PetitionCreator
     petition_creator_params[:location_code] || "GB-SCT"
   end
 
+  def privacy_notice
+    petition_creator_params[:privacy_notice] || "0"
+  end
+
   private
 
   def query_param
@@ -204,6 +209,7 @@ class PetitionCreator
     errors.add(:address, :too_long, count: 500) if address.length > 500
     errors.add(:postcode, :too_long, count: 255) if postcode.length > 255
     errors.add(:name, :has_uri) if URI::regexp =~ name
+    errors.add(:privacy_notice, :accepted) unless privacy_notice == "1"
 
     if email.present?
       email_validator.validate(self)

--- a/app/models/signature.rb
+++ b/app/models/signature.rb
@@ -45,12 +45,14 @@ class Signature < ActiveRecord::Base
   validates :postcode, presence: true, postcode: true, if: :united_kingdom?
   validates :postcode, length: { maximum: 255 }, allow_blank: true
   validates :constituency_id, length: { maximum: 255 }
+  validates :privacy_notice, acceptance: true, unless: :persisted?, allow_nil: false
 
   validate do
     errors.add(:name, :invalid) if name.to_s =~ /\A[-=+@]/
   end
 
   attr_readonly :sponsor, :creator
+  attr_accessor :privacy_notice
   attribute :locale, :string, default: -> { I18n.locale }
 
   before_validation if: :autocorrect_domain do

--- a/app/views/petitions/create/_creator_stage.html.erb
+++ b/app/views/petitions/create/_creator_stage.html.erb
@@ -51,6 +51,14 @@
   <%= form.text_field :postcode, class: "form-control small" %>
 <% end %>
 
+<%= form_row for: [petition, :privacy_notice] do %>
+  <div class="multiple-choice">
+    <%= error_messages_for_field petition, :privacy_notice %>
+    <%= form.check_box :privacy_notice %>
+    <%= form.label :privacy_notice, t(:"ui.petitions.create.creator_stage.privacy_notice.label").try(:html_safe), class: "privacy-notice" %>
+  </div>
+<% end %>
+
 <span>
   <%= t(:"ui.petitions.create.creator_stage.continue_html") %>
 </span>

--- a/app/views/petitions/create/_replay_email_stage.html.erb
+++ b/app/views/petitions/create/_replay_email_stage.html.erb
@@ -9,6 +9,7 @@
 <%= form.hidden_field :postcode %>
 <%= form.hidden_field :location_code %>
 <%= form.hidden_field :collect_signatures %>
+<%= form.hidden_field :privacy_notice %>
 
 <h1 class="page-title"><%= t(:"ui.petitions.create.replay_email_stage.heading") %></h1>
 

--- a/app/views/signatures/_email_form.html.erb
+++ b/app/views/signatures/_email_form.html.erb
@@ -4,6 +4,7 @@
 <%= form.hidden_field :postcode %>
 <%= form.hidden_field :location_code %>
 <%= form.hidden_field :notify_by_email %>
+<%= form.hidden_field :privacy_notice %>
 
 <%= form_row for: [signature, :email] do %>
   <%= form.label :email, t(:"ui.petitions.create.creator_stage.email.label"), class: "form-label visuallyhidden" %>

--- a/app/views/signatures/_form.html.erb
+++ b/app/views/signatures/_form.html.erb
@@ -31,6 +31,14 @@
   </div>
 <% end %>
 
+<%= form_row for: [signature, :privacy_notice] do %>
+  <div class="multiple-choice">
+    <%= error_messages_for_field signature, :privacy_notice %>
+    <%= form.check_box :privacy_notice %>
+    <%= form.label :privacy_notice, t(:"ui.petitions.create.creator_stage.privacy_notice.label").try(:html_safe), class: "privacy-notice" %>
+  </div>
+<% end %>
+
 <span>
   <%= t(:"ui.signatures.new.continue_html") %>
 </span>

--- a/config/locales/ui.en-GB.yml
+++ b/config/locales/ui.en-GB.yml
@@ -383,6 +383,9 @@ en-GB:
           notify_by_email:
             check_label: |-
               Email me whenever there’s an update about this petition
+          privacy_notice:
+            label: |-
+              Under data protection laws, we need you to confirm you have read our <a href="/privacy">privacy notice</a> and are content for us to use your data in the way described.
           about_published_data_html: |-
             <div class="secondary">
               <p>Your name will be published on this petition as the petition creator.</p>

--- a/config/locales/ui.gd-GB.yml
+++ b/config/locales/ui.gd-GB.yml
@@ -383,6 +383,9 @@ gd-GB:
           notify_by_email:
             check_label: |-
               Email me whenever there’s an update about this petition
+          privacy_notice:
+            label: |-
+              Under data protection laws, we need you to confirm you have read our <a href="/privacy">privacy notice</a> and are content for us to use your data in the way described.
           about_published_data_html: |-
             <div class="secondary">
               <p>Your name will be published on this petition as the petition creator.</p>

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -167,6 +167,7 @@ Scenario: Charlie tries to submit an invalid petition
   And I should see "Postcode must be completed"
   And I should see "Phone number must be completed"
   And I should see "Address must be completed"
+  And I should see "Privacy notice must be accepted"
 
   When I fill in "Address" with text longer than 500 characters
   And I fill in "Phone number" with "32000000000000000000000000000000"

--- a/features/step_definitions/rate_limit_steps.rb
+++ b/features/step_definitions/rate_limit_steps.rb
@@ -37,6 +37,7 @@ Given(/^there is a signature already from this IP address$/) do
     And I fill in "Email" with "existing@example.com"
     And I fill in my postcode with "SW14 9RQ"
     And I select "Wales" from "Location"
+    And I check "we need you to confirm you have read our privacy notice"
     And I try to sign
     And I say I am happy with my email address
     Then I am told to check my inbox to complete signing

--- a/features/step_definitions/signature_steps.rb
+++ b/features/step_definitions/signature_steps.rb
@@ -45,6 +45,7 @@ When(/^I fill in my details(?: with email "([^"]+)")?$/) do |email_address|
       And I fill in my postcode with "G34 0BX"
       And I select "Scotland" from "Location"
       And I check "Email me whenever there’s an update about this petition"
+      And I check "we need you to confirm you have read our privacy notice"
     )
   else
     steps %Q(
@@ -53,6 +54,7 @@ When(/^I fill in my details(?: with email "([^"]+)")?$/) do |email_address|
       And I fill in my postcode with "G34 0BX"
       And I select "Scotland" from "Location"
       And I check "Email me whenever there’s an update about this petition"
+      And I check "we need you to confirm you have read our privacy notice"
     )
   end
 end
@@ -84,6 +86,7 @@ When(/^I fill in my details with postcode "(.*?)"?$/) do |postcode|
     And I fill in my postcode with "#{postcode}"
     And I select "Wales" from "Location"
     And I check "Email me whenever there’s an update about this petition"
+    And I check "we need you to confirm you have read our privacy notice"
   )
 end
 
@@ -101,11 +104,13 @@ When(/^I fill in my creator contact details$/) do
     steps %Q(
       And I fill in "Phone number" with "0141 496 1234"
       And I fill in "Address" with "1 Nowhere Road, Glasgow"
+      And I check "we need you to confirm you have read our privacy notice"
     )
   else
     steps %Q(
       And I fill in "Phone number" with "0141 496 1234"
       And I fill in "Address" with "1 Nowhere Road, Glasgow"
+      And I check "we need you to confirm you have read our privacy notice"
     )
   end
 end

--- a/features/step_definitions/sponsor_steps.rb
+++ b/features/step_definitions/sponsor_steps.rb
@@ -25,6 +25,7 @@ When(/^a sponsor supports my petition$/) do
     And I fill in "Name" with "Anonymous Sponsor"
     And I fill in "Email" with "#{sponsor_email}"
     And I fill in my postcode with "G34 0BX"
+    And I check "we need you to confirm you have read our privacy notice"
     And I select "Wales" from "Location"
     And I try to sign
     And I say I am happy with my email address
@@ -58,6 +59,7 @@ Given(/^there is a sponsor already from this IP address$/) do
     And I fill in "Email" with "existing@example.com"
     And I fill in my postcode with "SW14 9RQ"
     And I select "Wales" from "Location"
+    And I check "we need you to confirm you have read our privacy notice"
     And I try to sign
     And I say I am happy with my email address
     Then I am told to check my inbox to complete signing
@@ -109,6 +111,7 @@ When(/^I fill in my details as a sponsor(?: with email "(.*?)")?$/) do |email_ad
     And I fill in my postcode with "AB10 1AA"
     And I select "Scotland" from "Location"
     And I check "Email me whenever there’s an update about this petition"
+    And I check "we need you to confirm you have read our privacy notice"
   }
 end
 

--- a/spec/controllers/petitions_controller_spec.rb
+++ b/spec/controllers/petitions_controller_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe PetitionsController, type: :controller do
         additional_details: "Global warming is upon us",
         name: "John Mcenroe", email: "john@example.com",
         phone_number: "0141 496 1234", address: "1 Nowhere Road, Cardiff",
-        postcode: "G34 0BX", location_code: "GB-SCT"
+        postcode: "G34 0BX", location_code: "GB-SCT",
+        privacy_notice: "1"
       }
     end
 
@@ -166,6 +167,15 @@ RSpec.describe PetitionsController, type: :controller do
           expect(response).to be_successful
         end
 
+        it "should not create a new petition if privacy_notice is not confirmed" do
+          perform_enqueued_jobs do
+            post :create, params: { stage: "replay_email", petition_creator: params.merge(privacy_notice: "0") }
+          end
+
+          expect(petition).to be_nil
+          expect(response).to be_successful
+        end
+
         it "has stage of 'petition' if there is an error on action" do
           perform_enqueued_jobs do
             post :create, params: { stage: "replay_email", petition_creator: params.merge(action: "") }
@@ -225,6 +235,14 @@ RSpec.describe PetitionsController, type: :controller do
         it "has stage of 'creator' if there are errors on email and we came from the 'creator' stage" do
           perform_enqueued_jobs do
             post :create, params: { stage: "creator", petition_creator: params.merge(email: "") }
+          end
+
+          expect(assigns[:new_petition].stage).to eq "creator"
+        end
+
+        it "has stage of 'creator' if there are errors on privacy_notice and we came from the 'creator' stage" do
+          perform_enqueued_jobs do
+            post :create, params: { stage: "creator", petition_creator: params.merge(privacy_notice: "0") }
           end
 
           expect(assigns[:new_petition].stage).to eq "creator"

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -90,7 +90,8 @@ RSpec.describe SignaturesController, type: :controller do
         name: "Ted Berry",
         email: "ted@example.com",
         postcode: "G34 0BX",
-        location_code: "GB-SCT"
+        location_code: "GB-SCT",
+        privacy_notice: "1"
       }
     end
 
@@ -167,6 +168,7 @@ RSpec.describe SignaturesController, type: :controller do
         expect(assigns[:signature].email).to eq("ted@example.com")
         expect(assigns[:signature].postcode).to eq("G340BX")
         expect(assigns[:signature].location_code).to eq("GB-SCT")
+        expect(assigns[:signature].privacy_notice).to eq("1")
       end
 
       it "records the IP address on the signature" do
@@ -216,7 +218,8 @@ RSpec.describe SignaturesController, type: :controller do
         name: "Ted Berry",
         email: "ted@example.com",
         postcode: "G34 0BX",
-        location_code: "GB-SCT"
+        location_code: "GB-SCT",
+        privacy_notice: "1"
       }
     end
 
@@ -296,6 +299,7 @@ RSpec.describe SignaturesController, type: :controller do
           expect(assigns[:signature].email).to eq("ted@example.com")
           expect(assigns[:signature].postcode).to eq("G340BX")
           expect(assigns[:signature].location_code).to eq("GB-SCT")
+          expect(assigns[:signature].privacy_notice).to eq("1")
         end
 
         it "records the IP address on the signature" do

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -133,7 +133,8 @@ RSpec.describe SponsorsController, type: :controller do
         name: "Ted Berry",
         email: "ted@example.com",
         postcode: "G34 0BX",
-        location_code: "GB-SCT"
+        location_code: "GB-SCT",
+        privacy_notice: "1"
       }
     end
 
@@ -255,7 +256,8 @@ RSpec.describe SponsorsController, type: :controller do
               name: "Ted Berry",
               email: "",
               postcode: "12345",
-              location_code: "GB-SCT"
+              location_code: "GB-SCT",
+              privacy_notice: "1"
             }
           end
 
@@ -289,7 +291,8 @@ RSpec.describe SponsorsController, type: :controller do
         name: "Ted Berry",
         email: "ted@example.com",
         postcode: "G34 0BX",
-        location_code: "GB-SCT"
+        location_code: "GB-SCT",
+        privacy_notice: "1"
       }
     end
 
@@ -419,7 +422,8 @@ RSpec.describe SponsorsController, type: :controller do
                 name: "Ted Berry",
                 email: "",
                 postcode: "G34 0BX",
-                location_code: "GB-SCT"
+                location_code: "GB-SCT",
+                privacy_notice: "1"
               }
             end
 

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -403,6 +403,7 @@ FactoryBot.define do
     postcode { "G34 0BX" }
     location_code { "GB-SCT" }
     notify_by_email { "1" }
+    privacy_notice { "1" }
     state { Signature::VALIDATED_STATE }
 
     after(:build) do |signature, evaluator|

--- a/spec/models/signature_spec.rb
+++ b/spec/models/signature_spec.rb
@@ -117,7 +117,7 @@ RSpec.describe Signature, type: :model do
             :pending_signature,
             petition: petition,
             constituency_id: "S16000147",
-            location_code: "GB-SCT"
+            location_code: "GB-SCT",
           )
         }
 
@@ -151,7 +151,7 @@ RSpec.describe Signature, type: :model do
             :pending_signature,
             petition: petition,
             constituency_id: "S16000147",
-            location_code: "GB"
+            location_code: "GB",
           )
         }
 
@@ -190,7 +190,8 @@ RSpec.describe Signature, type: :model do
           name: "Suzy Signer",
           email: email,
           postcode: postcode,
-          location_code: location_code
+          location_code: location_code,
+          privacy_notice: "1"
         }
       end
 
@@ -324,6 +325,21 @@ RSpec.describe Signature, type: :model do
       it "does not allow postcodes longer than 255 characters for non-UK addresses" do
         s = FactoryBot.build(:signature, :location_code => "US", :postcode => "1" * 256)
         expect(s).not_to have_valid(:postcode)
+      end
+    end
+
+    describe "privacy_notice" do
+      it "requires acceptance of privacy_notice for a new record" do
+        expect(FactoryBot.build(:signature, privacy_notice: "1")).to be_valid
+        expect(FactoryBot.build(:signature, privacy_notice: "0")).not_to be_valid
+        expect(FactoryBot.build(:signature, privacy_notice: nil)).not_to be_valid
+      end
+
+      it "does not require acceptance of privacy_notice for old records" do
+        signature = FactoryBot.create(:signature)
+        signature.reload
+        signature.privacy_notice = "0"
+        expect(signature).to be_valid
       end
     end
   end
@@ -921,7 +937,7 @@ RSpec.describe Signature, type: :model do
           :pending_signature,
           petition: petition,
           constituency_id: "S16000147",
-          location_code: "GB-SCT"
+          location_code: "GB-SCT",
         )
       }
 
@@ -2110,7 +2126,8 @@ RSpec.describe Signature, type: :model do
           name: "Suzy Signer",
           email: "foo@example.com",
           postcode: "G34 0BX",
-          location_code: "GB-SCT"
+          location_code: "GB-SCT",
+          privacy_notice: "1"
         )
       end
 
@@ -2184,14 +2201,16 @@ RSpec.describe Signature, type: :model do
           name: "Suzy Signer",
           email: "foo@example.com",
           postcode: "G34 0BX",
-          location_code: "GB-SCT"
+          location_code: "GB-SCT",
+          privacy_notice: "1"
         )
 
         petition.signatures.create!(
           name: "Sam Signer",
           email: "foo@example.com",
           postcode: "G34 0BX",
-          location_code: "GB-SCT"
+          location_code: "GB-SCT",
+          privacy_notice: "1"
         )
       end
 
@@ -2220,7 +2239,8 @@ RSpec.describe Signature, type: :model do
         name: "Suzy Signer",
         email: "foo@example.com",
         postcode: "G34 0BX",
-        location_code: "GB-SCT"
+        location_code: "GB-SCT",
+        privacy_notice: "1"
       }
     end
 


### PR DESCRIPTION
Petitioners must acknowledge the privacy policy before creating their petition

https://trello.com/c/Ojx8IaD2/50-as-a-petition-creator-or-petitions-clerk-i-want-to-confirm-understanding-of-the-sp-privacy-notice

<img width="1015" alt="Screenshot 2021-02-10 at 16 52 52" src="https://user-images.githubusercontent.com/35098639/107777756-2d926900-6d3b-11eb-9947-af7ea8b291ba.png">

<img width="798" alt="Screenshot 2021-02-12 at 14 04 41" src="https://user-images.githubusercontent.com/35098639/107777849-469b1a00-6d3b-11eb-8160-8710569e1d2f.png">

