### PR TITLE
Open privacy notice read check in separate tab

### DIFF
--- a/config/locales/ui.en-GB.yml
+++ b/config/locales/ui.en-GB.yml
@@ -385,7 +385,7 @@ en-GB:
               Email me whenever there’s an update about this petition
           privacy_notice:
             label: |-
-              Under data protection laws, we need you to confirm you have read our <a href="/privacy">privacy notice</a> and are content for us to use your data in the way described.
+              Under data protection laws, we need you to confirm you have read our <a href="/privacy" target="_blank">privacy notice</a> (opens in a new tab) and are content for us to use your data in the way described.
           about_published_data_html: |-
             <div class="secondary">
               <p>Your name will be published on this petition as the petition creator.</p>

--- a/config/locales/ui.gd-GB.yml
+++ b/config/locales/ui.gd-GB.yml
@@ -385,7 +385,7 @@ gd-GB:
               Email me whenever there’s an update about this petition
           privacy_notice:
             label: |-
-              Under data protection laws, we need you to confirm you have read our <a href="/privacy">privacy notice</a> and are content for us to use your data in the way described.
+              Under data protection laws, we need you to confirm you have read our <a href="/privacy" target="_blank">privacy notice</a> (opens in a new tab) and are content for us to use your data in the way described.
           about_published_data_html: |-
             <div class="secondary">
               <p>Your name will be published on this petition as the petition creator.</p>


### PR DESCRIPTION
This prevents the user's filled in data from being lost when they click on the privacy notice, though is not ideal for accessibility and use on mobile.