### PR TITLE
Show petition creator name on all statuses and on csv/json

### DIFF
--- a/app/views/petitions/_closed_petition_show.html.erb
+++ b/app/views/petitions/_closed_petition_show.html.erb
@@ -44,6 +44,7 @@
 
   <ul class="petition-meta">
     <li>
+      <span class="label"><%= t(:"ui.petitions.created_by") %></span> <%= petition.creator.name %>
       <% if @petition.completed? %>
         <span class="label"><%= t(:"ui.petitions.date_completed") %></span> <%= short_date_format petition.completed_at %>
       <% elsif @petition.submitted_on_paper? %>

--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -9,6 +9,7 @@ json.attributes do
   json.action petition.action
   json.background petition.background
   json.additional_details petition.additional_details
+  json.petitioner petition.creator.name
   json.committee_note petition.committee_note
   json.state petition.state
   json.signature_count petition.signature_count

--- a/app/views/petitions/index.csv.ruby
+++ b/app/views/petitions/index.csv.ruby
@@ -1,11 +1,12 @@
 csv_builder = lambda do |csv|
-  csv << ['Petition', 'URL', 'PE Number', 'State', 'Signatures Count']
+  csv << ['Petition', 'URL', 'PE Number', 'Petitioner', 'State', 'Signatures Count']
 
   @petitions.find_each do |petition|
     csv << [
       csv_escape(petition.action),
       petition_url(petition),
       petition.to_param,
+      petition.creator.name,
       petition.state,
       petition.signature_count
     ]


### PR DESCRIPTION
https://trello.com/c/TQ6WWkBw/109-as-a-petitioner-signee-member-of-the-public-clerk-i-want-to-see-the-petitioners-name

Petition creator's name should be viewable everywhere, apart from on rejected petitions. But since those are hidden anyway, doesn't really affect this. 