### PR TITLE
Resend the correct email to petition creators

### DIFF
--- a/app/controllers/admin/petitions_controller.rb
+++ b/app/controllers/admin/petitions_controller.rb
@@ -23,8 +23,12 @@ class Admin::PetitionsController < Admin::AdminController
   end
 
   def resend
-    GatherSponsorsForPetitionEmailJob.perform_later(@petition.creator)
-    GatherSponsorsForPetitionEmailJob.perform_later(feedback_signature)
+    if Site.collecting_sponsors?
+      GatherSponsorsForPetitionEmailJob.perform_later(@petition.creator)
+      GatherSponsorsForPetitionEmailJob.perform_later(feedback_signature)
+    else
+      EmailConfirmationForCreatorEmailJob.perform_later(@petition.creator)
+    end
 
     redirect_to admin_petition_url(@petition), notice: :email_resent_to_creator
   end

--- a/app/jobs/email_confirmation_for_creator_email_job.rb
+++ b/app/jobs/email_confirmation_for_creator_email_job.rb
@@ -1,8 +1,6 @@
 class EmailConfirmationForCreatorEmailJob < NotifyJob
   self.template = :email_confirmation_for_creator
 
-  include RateLimiting
-
   def personalisation(signature, petition)
     {
       action_en:  petition.action_en, action_gd: petition.action_gd,


### PR DESCRIPTION
When we're not collecting signatures the correct email to resend is the validate signature email and not the gather sponsors email.

The rate limiting inside the email job has been removed as this is handled within the petition creator form directly.

We also don't send a copy to the feedback address as moderators can validate petition creators signatures directly - the copy of the gather sponsors email is sent so that moderators could have access to the 'Sponsor this petition' link.