### PR TITLE
Make Notifications::Event quack like a hash

### DIFF
--- a/app/lib/notifications/event.rb
+++ b/app/lib/notifications/event.rb
@@ -1,5 +1,5 @@
 module Notifications
-  class Event
+  class Event < Hash
     TYPES = {
       "Delivery"          => "delivery",
       "Bounce"            => "bounce",
@@ -17,27 +17,25 @@ module Notifications
       end
     end
 
-    attr_reader :data, :mail
-
     def initialize(data)
-      @data = data
-      @mail = @data.fetch("mail")
+      super()
+      update(data)
     end
 
     def message_id
-      mail.fetch("messageId")
+      @message_id ||= dig("mail", "messageId")
     end
 
     def timestamp
-      @timestamp ||= mail.fetch("timestamp").in_time_zone
+      @timestamp ||= dig("mail", "timestamp").in_time_zone
     end
 
     def type
-      @type ||= TYPES[data.fetch("eventType")]
+      @type ||= TYPES[fetch("eventType")]
     end
 
     def payload
-      @payload ||= data.fetch(type)
+      @payload ||= fetch(type)
     end
   end
 end

--- a/spec/lib/notifications/event_spec.rb
+++ b/spec/lib/notifications/event_spec.rb
@@ -69,6 +69,14 @@ RSpec.describe Notifications::Event do
       end
     end
 
+    describe "duck typing" do
+      subject { described_class.parse(sns) }
+
+      it "quacks like a Hash" do
+        expect(subject).to be_a(Hash)
+      end
+    end
+
     describe "instance methods" do
       subject { described_class.parse(sns) }
 


### PR DESCRIPTION
By making the event inherit from Hash, Appsignal will log the full event details which will make things easier to debug if there are any problems.