### PR TITLE
Ensure petitions go to moderation

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -531,6 +531,10 @@ class Petition < ActiveRecord::Base
     collect_signatures? ? super : 0
   end
 
+  def real_signature_count
+    self[:signature_count]
+  end
+
   def to_param
     published? ? ('PE%04d' % pe_number_id) : ('PP%04d' % id)
   end
@@ -633,37 +637,37 @@ class Petition < ActiveRecord::Base
 
   def will_reach_threshold_for_moderation?
     unless moderation_threshold_reached_at?
-      signature_count >= Site.threshold_for_moderation
+      real_signature_count >= Site.threshold_for_moderation
     end
   end
 
   def at_threshold_for_moderation?
     unless moderation_threshold_reached_at?
-      signature_count >= Site.threshold_for_moderation + 1
+      real_signature_count >= Site.threshold_for_moderation + 1
     end
   end
 
   def at_threshold_for_referral?
     unless referral_threshold_reached_at?
-      signature_count >= Site.threshold_for_referral
+      real_signature_count >= Site.threshold_for_referral
     end
   end
 
   def at_threshold_for_debate?
     unless debate_threshold_reached_at?
-      signature_count >= Site.threshold_for_debate
+      real_signature_count >= Site.threshold_for_debate
     end
   end
 
   def below_threshold_for_referral?
     if referral_threshold_reached_at?
-      signature_count <= Site.threshold_for_referral
+      real_signature_count <= Site.threshold_for_referral
     end
   end
 
   def below_threshold_for_debate?
     if debate_threshold_reached_at?
-      signature_count <= Site.threshold_for_debate
+      real_signature_count <= Site.threshold_for_debate
     end
   end
 

--- a/features/charlie_creates_a_petition.feature
+++ b/features/charlie_creates_a_petition.feature
@@ -23,7 +23,8 @@ Scenario: Charlie cannot craft an xss attack when searching for petitions
   Then the markup should be valid
 
 Scenario: Charlie creates a petition
-  Given I start a new petition
+  Given the site is not collecting sponsors
+  And I start a new petition
   And I fill in the petition details
   And I press "Preview petition"
   And I press "This looks good"
@@ -36,8 +37,10 @@ Scenario: Charlie creates a petition
   When I press "Yes – this is my email address"
   Then a petition should exist with action_en: "The wombats of wimbledon rock.", action_gd: nil, state: "pending", locale: "en-GB", collect_signatures: false
   And there should be a "pending" signature with email "womboid@wimbledon.com" and name "Womboid Wibbledon"
-  And "Womboid Wibbledon" wants to be notified about the petition's progress
-  And "womboid@wimbledon.com" should be emailed a link for gathering support from sponsors
+  And "womboid@wimbledon.com" should be emailed a link for validating their signature
+  When I confirm my email
+  Then a petition should exist with action_en: "The wombats of wimbledon rock.", state: "sponsored"
+  And I should see "We’re checking this petition"
 
 Scenario: Charlie creates a petition and wants to collect signatures
   Given the date is the "20 April, 2020"
@@ -74,7 +77,7 @@ Scenario: Charlie creates a petition when sponsor count is set to 0
   And "womboid@wimbledon.com" should be emailed a link for validating their signature
   When I confirm my email
   Then a petition should exist with action_en: "The wombats of wimbledon rock.", state: "sponsored"
-  Then I should see "We’re checking this petition"
+  And I should see "We’re checking this petition"
 
 @gaelic
 Scenario: Charlie creates a petition in Gaelic

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1981,6 +1981,38 @@ RSpec.describe Petition, type: :model do
         expect(petition.at_threshold_for_moderation?).to be_falsey
       end
     end
+
+    context "when the petition is not collecting signatures" do
+      let(:petition) { FactoryBot.create(:pending_petition, signature_count: signature_count, collect_signatures: false) }
+
+      before do
+        expect(Site).to receive(:threshold_for_moderation).and_return(0)
+      end
+
+      context "and the signature count is less than the threshold" do
+        let(:signature_count) { 0 }
+
+        it "is falsey" do
+          expect(petition.at_threshold_for_moderation?).to be_falsey
+        end
+      end
+
+      context "and the signature count is equal to the threshold" do
+        let(:signature_count) { 1 }
+
+        it "is truthy" do
+          expect(petition.at_threshold_for_moderation?).to be_truthy
+        end
+      end
+
+      context "and the signature count is more than the threshold" do
+        let(:signature_count) { 2 }
+
+        it "is truthy" do
+          expect(petition.at_threshold_for_moderation?).to be_truthy
+        end
+      end
+    end
   end
 
   describe "at_threshold_for_referral?" do


### PR DESCRIPTION
When the signature_count method was overridden this broke moderation for petitions that aren't collecting signatures because they never reach the moderation threshold. Fix this by adding a 'real' method that returns the actual value for our threshold methods.