### PR TITLE
Make moderation more robust against errors

### DIFF
--- a/app/controllers/admin/take_down_controller.rb
+++ b/app/controllers/admin/take_down_controller.rb
@@ -6,7 +6,7 @@ class Admin::TakeDownController < Admin::AdminController
   end
 
   def update
-    if @petition.reject(rejection_params[:rejection])
+    if @petition.moderate(moderation_params)
       send_notifications
       redirect_to [:admin, @petition]
     else
@@ -20,8 +20,16 @@ class Admin::TakeDownController < Admin::AdminController
     @petition = Petition.find(params[:petition_id])
   end
 
+  def moderation_params
+    rejection_params.merge(moderation: "reject")
+  end
+
   def rejection_params
-    params.require(:petition).permit(rejection: [:code, :details_en, :details_gd])
+    params.require(:petition).permit(*rejection_attributes)
+  end
+
+  def rejection_attributes
+    [ rejection: [:code, :details_en, :details_gd] ]
   end
 
   def send_notifications

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -792,23 +792,29 @@ class Petition < ActiveRecord::Base
 
       case moderation
       when 'approve'
-        publish
+        publish!
       when 'reject'
-        reject(params[:rejection])
+        reject!(params[:rejection])
       when 'flag'
-        update(state: FLAGGED_STATE)
+        update!(state: FLAGGED_STATE)
       when 'unflag', 'restore'
-        update(state: SPONSORED_STATE)
+        update!(state: SPONSORED_STATE)
       else
-        if flagged?
-          errors.add :moderation, :blank, action: 'unflag'
-        else
-          errors.add :moderation, :blank, action: 'flag'
-        end
-
-        false
+        errors.add :moderation, :blank
+        raise ActiveRecord::RecordNotSaved, "Unable to moderate petition"
       end
     end
+
+    if published?
+      Appsignal.increment_counter("petition.published", 1)
+    elsif rejected?
+      Appsignal.increment_counter("petition.rejected", 1)
+    end
+
+    true
+  rescue ActiveRecord::RecordNotSaved, ActiveRecord::RecordInvalid
+    reload_rejection unless rejection.present?
+    false
   end
 
   def moderating?
@@ -823,21 +829,22 @@ class Petition < ActiveRecord::Base
     state.in?(REJECTED_STATES) && state_was.in?(PUBLISHABLE_STATES + VISIBLE_STATES)
   end
 
-  def publish(time = Time.current)
+  def publish!(time = Time.current)
     errors.add :moderation, :translation_missing unless translated?
     errors.add :moderation, :still_pending if pending?
-    return false if errors.any?
 
-    Appsignal.increment_counter("petition.published", 1)
+    if errors.any?
+      raise ActiveRecord::RecordNotSaved, "Unable to moderate petition"
+    end
 
     update!(
       state: state_for_publishing,
-      referred_at: referred_at_for_publishing(time),
-      open_at: time, closed_at: closing_date(time)
+      open_at: time_for_publishing(time),
+      closed_at: closing_date(time)
     )
   end
 
-  def reject(attributes)
+  def reject!(attributes)
     begin
       if rejection.present?
         rejection.attributes = attributes
@@ -863,17 +870,9 @@ class Petition < ActiveRecord::Base
         end
       end
 
-      Appsignal.increment_counter("petition.rejected", 1)
-
-      rejection.save
+      rejection.save!
     rescue ActiveRecord::RecordNotUnique => e
-      reload_rejection.update(attributes)
-    end
-  end
-
-  def reject!(attributes)
-    unless reject(attributes)
-      raise ActiveRecord::RecordNotSaved, "Failed to save the rejection details"
+      reload_rejection.update!(attributes)
     end
   end
 
@@ -1019,6 +1018,10 @@ class Petition < ActiveRecord::Base
     rejected? || hidden?
   end
 
+  def previously_published?(now = Time.current)
+    open_at && open_at < now
+  end
+
   def update_lock!(user, now = Time.current)
     if locked_by == user
       update!(locked_at: now)
@@ -1157,6 +1160,10 @@ class Petition < ActiveRecord::Base
 
   def state_for_publishing
     collect_signatures? ? OPEN_STATE : CLOSED_STATE
+  end
+
+  def time_for_publishing(time)
+    open_at || time
   end
 
   def referred_at_for_publishing(time)

--- a/app/views/admin/moderation/_form.html.erb
+++ b/app/views/admin/moderation/_form.html.erb
@@ -6,31 +6,34 @@
       <h2 class="petition-action-heading">Moderate this petition</h2>
     <% end %>
     <%= error_messages_for_field petition, :moderation %>
+    <%= f.hidden_field :moderation, value: "" %>
     <div class="multiple-choice">
       <%= f.radio_button :moderation, 'approve' %>
       <%= f.label :moderation_approve, "Approve", for: "petition_moderation_approve" %>
     </div>
-    <% if f.object.rejection? %>
-      <div class="multiple-choice">
-      <%= f.radio_button :moderation, 'restore' %>
-      <%= f.label :moderation_reject, "Restore", for: "petition_moderation_restore" %>
-      </div>
-    <% else %>
-      <div class="multiple-choice">
-      <%= f.radio_button :moderation, 'reject' %>
-      <%= f.label :moderation_reject, "Reject", for: "petition_moderation_reject" %>
-      </div>
-    <% end %>
-    <% if f.object.flagged? %>
-      <div class="multiple-choice">
-        <%= f.radio_button :moderation, 'unflag' %>
-        <%= f.label :moderation_unflag, "Unflag", for: "petition_moderation_unflag" %>
-      </div>
-    <% elsif !f.object.published? %>
-      <div class="multiple-choice">
-        <%= f.radio_button :moderation, 'flag' %>
-        <%= f.label :moderation_flag, "Flag", for: "petition_moderation_flag" %>
-      </div>
+    <% unless f.object.previously_published? %>
+      <% if f.object.rejection? %>
+        <div class="multiple-choice">
+        <%= f.radio_button :moderation, 'restore' %>
+        <%= f.label :moderation_reject, "Restore", for: "petition_moderation_restore" %>
+        </div>
+      <% else %>
+        <div class="multiple-choice">
+        <%= f.radio_button :moderation, 'reject' %>
+        <%= f.label :moderation_reject, "Reject", for: "petition_moderation_reject" %>
+        </div>
+      <% end %>
+      <% if f.object.flagged? %>
+        <div class="multiple-choice">
+          <%= f.radio_button :moderation, 'unflag' %>
+          <%= f.label :moderation_unflag, "Unflag", for: "petition_moderation_unflag" %>
+        </div>
+      <% else !f.object.published? %>
+        <div class="multiple-choice">
+          <%= f.radio_button :moderation, 'flag' %>
+          <%= f.label :moderation_flag, "Flag", for: "petition_moderation_flag" %>
+        </div>
+      <% end %>
     <% end %>
   <% end %>
 

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -117,7 +117,7 @@ en-GB:
         petition:
           attributes:
             moderation:
-              blank: "You must choose to approve, reject or %{action}"
+              blank: "You must choose a moderation action"
               translation_missing: "The petition must be fully translated first before being made public"
               still_pending: "You can't publish a petition before the creator has validated their email address"
             creator_signature:

--- a/spec/factories.rb
+++ b/spec/factories.rb
@@ -438,7 +438,13 @@ FactoryBot.define do
 
     after(:create) do |signature, evaluator|
       if evaluator.increment && signature.petition
-        signature.petition.increment_signature_count!
+        petition = signature.petition
+        last_signed_at = petition.last_signed_at
+
+        if petition.increment_signature_count!
+          ConstituencyPetitionJournal.increment_signature_counts_for(petition, last_signed_at)
+          CountryPetitionJournal.increment_signature_counts_for(petition, last_signed_at)
+        end
       end
     end
   end

--- a/spec/jobs/notify_everyone_of_failure_to_get_enough_signatures_job_spec.rb
+++ b/spec/jobs/notify_everyone_of_failure_to_get_enough_signatures_job_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe NotifyEveryoneOfFailureToGetEnoughSignaturesJob, type: :job do
 
   context "when the petition fails to get enough signatures" do
     before do
-      petition.reject(code: "insufficient")
+      petition.reject!(code: "insufficient")
     end
 
     it "notifies the creator" do

--- a/spec/jobs/notify_everyone_of_moderation_decision_job_spec.rb
+++ b/spec/jobs/notify_everyone_of_moderation_decision_job_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe NotifyEveryoneOfModerationDecisionJob, type: :job do
 
   context "when the petition is published" do
     before do
-      petition.publish
+      petition.publish!
     end
 
     it "notifies the creator" do
@@ -42,7 +42,7 @@ RSpec.describe NotifyEveryoneOfModerationDecisionJob, type: :job do
     let(:rejection) { petition.rejection }
 
     before do
-      petition.reject(code: "duplicate")
+      petition.reject!(code: "duplicate")
     end
 
     it "notifies the creator" do
@@ -82,7 +82,7 @@ RSpec.describe NotifyEveryoneOfModerationDecisionJob, type: :job do
     let(:rejection) { petition.rejection }
 
     before do
-      petition.reject(code: "offensive")
+      petition.reject!(code: "offensive")
     end
 
     it "notifies the creator" do

--- a/spec/models/constituency_petition_journal_spec.rb
+++ b/spec/models/constituency_petition_journal_spec.rb
@@ -73,7 +73,7 @@ RSpec.describe ConstituencyPetitionJournal, type: :model do
     let(:signature_count) { 1 }
 
     context "when the supplied signature is valid" do
-      let(:signature) { FactoryBot.create(:validated_signature, petition: petition, constituency_id: constituency_id) }
+      let!(:signature) { FactoryBot.create(:validated_signature, petition: petition, constituency_id: constituency_id) }
       let(:now) { 1.hour.from_now.change(usec: 0) }
 
       it "decrements the signature_count by 1" do

--- a/spec/models/country_petition_jounal_spec.rb
+++ b/spec/models/country_petition_jounal_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe CountryPetitionJournal, type: :model do
     let(:signature_count) { 1 }
 
     context "when the supplied signature is valid" do
-      let(:signature) { FactoryBot.create(:validated_signature, petition: petition, location_code: "GB-SCT") }
+      let!(:signature) { FactoryBot.create(:validated_signature, petition: petition, location_code: "GB-SCT") }
       let(:now) { 1.hour.from_now.change(usec: 0) }
 
       it "decrements the signature_count by 1" do


### PR DESCRIPTION
You can't just return false from inside a transaction as you need to raise an exception to generate the rollback.