### PR TITLE
Add flash alert messages to the top of the admin pages

### DIFF
--- a/app/controllers/admin/completion_date_controller.rb
+++ b/app/controllers/admin/completion_date_controller.rb
@@ -9,7 +9,7 @@ class Admin::CompletionDateController < Admin::AdminController
     if @petition.update(petition_params)
       redirect_to [:admin, @petition], notice: :completion_date_updated
     else
-      render 'admin/petitions/show'
+      render 'admin/petitions/show', alert: :petition_not_saved
     end
   end
 

--- a/app/controllers/admin/moderation_controller.rb
+++ b/app/controllers/admin/moderation_controller.rb
@@ -7,7 +7,7 @@ class Admin::ModerationController < Admin::AdminController
       send_notifications
       redirect_to [:admin, @petition], notice: :petition_updated
     else
-      render 'admin/petitions/show'
+      render 'admin/petitions/show', alert: :petition_not_saved
     end
   end
 

--- a/app/controllers/admin/notes_controller.rb
+++ b/app/controllers/admin/notes_controller.rb
@@ -14,7 +14,7 @@ class Admin::NotesController < Admin::AdminController
     if @note.update(note_params)
       redirect_to [:admin, @petition]
     else
-      render 'admin/petitions/show'
+      render 'admin/petitions/show', alert: :petition_not_updated
     end
   end
 

--- a/app/controllers/admin/petition_tags_controller.rb
+++ b/app/controllers/admin/petition_tags_controller.rb
@@ -9,7 +9,7 @@ class Admin::PetitionTagsController < Admin::AdminController
     if @petition.update(petition_params)
       redirect_to [:admin, @petition], notice: :petition_updated
     else
-      render 'admin/petitions/show'
+      render 'admin/petitions/show', alert: :petition_not_updated
     end
   end
 

--- a/app/controllers/admin/petition_topics_controller.rb
+++ b/app/controllers/admin/petition_topics_controller.rb
@@ -9,7 +9,7 @@ class Admin::PetitionTopicsController < Admin::AdminController
     if @petition.update(petition_params)
       redirect_to [:admin, @petition], notice: :petition_updated
     else
-      render 'admin/petitions/show'
+      render 'admin/petitions/show', alert: :petition_not_updated
     end
   end
 

--- a/app/controllers/admin/schedule_debate_controller.rb
+++ b/app/controllers/admin/schedule_debate_controller.rb
@@ -16,7 +16,7 @@ class Admin::ScheduleDebateController < Admin::AdminController
 
       redirect_to [:admin, @petition], notice: message
     else
-      render 'admin/petitions/show'
+      render 'admin/petitions/show', alert: :petition_not_saved
     end
   end
 

--- a/app/controllers/admin/scot_parl_link_controller.rb
+++ b/app/controllers/admin/scot_parl_link_controller.rb
@@ -9,7 +9,7 @@ class Admin::ScotParlLinkController < Admin::AdminController
     if @petition.update(petition_params)
       redirect_to [:admin, @petition], notice: :petition_updated
     else
-      render 'admin/petitions/show'
+      render 'admin/petitions/show', alert: :petition_not_saved
     end
   end
 

--- a/app/controllers/admin/take_down_controller.rb
+++ b/app/controllers/admin/take_down_controller.rb
@@ -10,7 +10,7 @@ class Admin::TakeDownController < Admin::AdminController
       send_notifications
       redirect_to [:admin, @petition]
     else
-      render 'admin/petitions/show'
+      render 'admin/petitions/show', alert: :petition_not_taken_down
     end
   end
 

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -151,6 +151,8 @@ class Petition < ActiveRecord::Base
   validates :state, inclusion: { in: STATES }
   validates :collect_signatures, inclusion: [true, false]
 
+  validates :completed_at, presence: true, if: :completed?
+
   with_options allow_nil: true, prefix: true do
     delegate :name, :email, to: :creator
     delegate :code, :details, to: :rejection

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -145,6 +145,12 @@ class Petition < ActiveRecord::Base
     errors.add :previous_action, :too_long, count: 4000 if t.previous_action.length > 4000
   end
 
+  # The scheduled_debate_date will be blank for most petitions but we
+  # can't add `allow_blank: true` here because Active Record validations
+  # will not call the DateValidator as all invalid dates are coerced to nil.
+  # Therefore the allowing of blank values is handling in the validtor.
+  validates :scheduled_debate_date, date: true
+
   validates :committee_note, length: { maximum: 800, allow_blank: true }
   validates :open_at, presence: true, if: :open?
   validates :creator, presence: true, unless: :completed?

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -151,6 +151,9 @@ class Petition < ActiveRecord::Base
   validates :state, inclusion: { in: STATES }
   validates :collect_signatures, inclusion: [true, false]
 
+  validates :scot_parl_link_en, url: true
+  validates :scot_parl_link_gd, url: true, unless: :gaelic_disabled?
+
   validates :completed_at, presence: true, if: :completed?
 
   with_options allow_nil: true, prefix: true do

--- a/app/validators/date_validator.rb
+++ b/app/validators/date_validator.rb
@@ -1,0 +1,13 @@
+class DateValidator < ActiveModel::EachValidator
+  def validate_each(record, attribute, value)
+    value = record.read_attribute_before_type_cast(attribute)
+
+    if value.present? && value.acts_like?(:string)
+      begin
+        Date.parse(value.to_s)
+      rescue ArgumentError
+        record.errors.add(attribute, (options[:message] || :invalid))
+      end
+    end
+  end
+end

--- a/app/views/admin/completion_date/_petition_action_completion_date.html.erb
+++ b/app/views/admin/completion_date/_petition_action_completion_date.html.erb
@@ -1,7 +1,9 @@
-<%= form_for petition, url: admin_petition_completion_date_path(petition), method: :patch do |f| %>
 
-  <%= form_row for: [f.object, :closed_at] do %>
-    <%= f.label :completed_at, "Completion date", class: 'form-label' %>
+<%= form_for petition, url: admin_petition_completion_date_path(petition), method: :patch do |f| %>
+  <%= form_row for: [f.object, :completed_at] do %>
+    <%= f.label :completed_at, class: 'form-label', for: 'petition_completed_at_3i' do %>
+      <h2 class="petition-action-heading">Change closed date</h2>
+    <% end %>
     <%= error_messages_for_field @petition, :completed_at %>
     <%= f.date_select :completed_at, { include_blank: true }, tabindex: increment, class: 'form-control form-control-auto' %>
     <%= hidden_field_tag "petition[completed_at(4i)]", "0" %>

--- a/app/views/admin/debate_outcomes/_petition_action_debate_outcome.html.erb
+++ b/app/views/admin/debate_outcomes/_petition_action_debate_outcome.html.erb
@@ -106,8 +106,8 @@
   </div>
 
   <%= email_petitioners_with_count_submit_button(f, petition) %>
-
   <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+  <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
 <% end -%>
 
 <%= javascript_tag do %>

--- a/app/views/admin/petitions/_petition_details.html.erb
+++ b/app/views/admin/petitions/_petition_details.html.erb
@@ -6,13 +6,13 @@
     <dt>Archived on</dt>
     <dd><%= date_format_admin(@petition.archived_at) %></dd>
   <% elsif @petition.completed? %>
-    <dt>Completed on</dt>
+    <dt>Closed on</dt>
     <dd><%= date_format_admin(@petition.completed_at) %></dd>
   <% elsif @petition.rejection? %>
     <dt>Rejected on</dt>
     <dd><%= date_format_admin(@petition.rejected_at) %></dd>
   <% elsif @petition.closed? %>
-    <dt>Closed on</dt>
+    <dt>Under consideration from</dt>
     <dd><%= date_format_admin(@petition.closed_at) %></dd>
   <% elsif @petition.open? %>
     <dt>Deadline</dt>

--- a/app/views/admin/petitions/index.html.erb
+++ b/app/views/admin/petitions/index.html.erb
@@ -83,7 +83,13 @@
         <% else %>
           <td class="date"><%= date_format(petition.deadline) || "—" %></td>
         <% end %>
-        <td class="numeric last"><%= number_with_delimiter(petition.signature_count) %></td>
+        <td class="numeric last">
+          <% if petition.collect_signatures? %>
+            <%= number_with_delimiter(petition.signature_count) %>
+          <% else %>
+            –
+          <% end %>
+        </td>
       </tr>
     <% end -%>
   </tbody>

--- a/app/views/admin/schedule_debate/_petition_action_debate_date.html.erb
+++ b/app/views/admin/schedule_debate/_petition_action_debate_date.html.erb
@@ -7,8 +7,8 @@
   <% end %>
 
   <%= email_petitioners_with_count_submit_button(f, petition) %>
-
   <%= f.submit "Save without emailing", name: 'save', class: 'button-secondary' %>
+  <%= link_to 'Cancel', admin_petition_path(@petition), class: 'button-secondary' %>
 <% end %>
 
 <%= render 'edit_lock' %>

--- a/app/views/admin/take_down/_petition_action_change_rejection_status.html.erb
+++ b/app/views/admin/take_down/_petition_action_change_rejection_status.html.erb
@@ -9,6 +9,7 @@
 
   <%= f.submit "Email petition creator", name: 'save_and_email', class: 'button' %>
   <%= f.submit 'Save without emailing', name: 'save', class: 'button-secondary', tabindex: increment %>
+  <%= link_to 'Cancel', admin_petition_path(petition), class: 'button-secondary' %>
 <% end -%>
 
 <%= render 'edit_lock' %>

--- a/app/views/admin/take_down/_petition_action_take_down.html.erb
+++ b/app/views/admin/take_down/_petition_action_take_down.html.erb
@@ -1,8 +1,11 @@
 <h2 class="petition-action-heading">Take this petition down</h2>
+
 <%= form_for petition, url: admin_petition_take_down_path(petition), method: :patch do |f| -%>
   <%= render 'admin/petitions/reject', f: f %>
 
   <%= f.submit "Email petition creator", name: 'save_and_email', class: 'button' %>
   <%= f.submit 'Save without emailing', name: 'save', class: 'button-secondary', tabindex: increment %>
+  <%= link_to 'Cancel', admin_petition_path(petition), class: 'button-secondary' %>
 <% end -%>
+
 <%= render 'edit_lock' %>

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -134,6 +134,8 @@ en-GB:
               invalid: "Please use a valid http or https url"
             completed_at:
               blank: "Please enter the date when the petition was closed"
+            scheduled_debate_date:
+              invalid: "Please enter a valid date for when the debate will happen"
 
         petition/email:
           attributes:

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -128,6 +128,8 @@ en-GB:
               invalid: "The submitted tags were invalid - please reselect and try again"
             topics:
               invalid: "The submitted topics were invalid - please reselect and try again"
+            completed_at:
+              blank: "Please enter the date when the petition was closed"
 
         petition/email:
           attributes:

--- a/config/locales/activerecord.en-GB.yml
+++ b/config/locales/activerecord.en-GB.yml
@@ -128,6 +128,10 @@ en-GB:
               invalid: "The submitted tags were invalid - please reselect and try again"
             topics:
               invalid: "The submitted topics were invalid - please reselect and try again"
+            scot_parl_link_en:
+              invalid: "Please use a valid http or https url"
+            scot_parl_link_gd:
+              invalid: "Please use a valid http or https url"
             completed_at:
               blank: "Please enter the date when the petition was closed"
 

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -92,6 +92,7 @@ en-GB:
       petition_content_copied: "The petition's content has been copied over to the Gaelic version"
       petition_content_reset: "The Gaelic version of the petition's content has been reset"
       petition_not_saved: "Petition could not be updated - please check the form for errors"
+      petition_not_taken_down: "Petition could not be taken down - please check the form for errors"
       preview_email_sent: "Preview email successfully sent"
       rate_limits_updated: "Rate limits updated successfully"
       rejection_reason_created: "Rejection reason created successfully"

--- a/config/locales/admin.en-GB.yml
+++ b/config/locales/admin.en-GB.yml
@@ -91,7 +91,7 @@ en-GB:
       petition_not_updated: "Petition could not be updated - please contact support"
       petition_content_copied: "The petition's content has been copied over to the Gaelic version"
       petition_content_reset: "The Gaelic version of the petition's content has been reset"
-      petition_not_saved: "Petition could not be saved - please check the form for errors"
+      petition_not_saved: "Petition could not be updated - please check the form for errors"
       preview_email_sent: "Preview email successfully sent"
       rate_limits_updated: "Rate limits updated successfully"
       rejection_reason_created: "Rejection reason created successfully"

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -174,9 +174,9 @@ Feature: Suzie views a petition
 
   Scenario Outline: Suzie sees the correct wording for petitions with a ScotParl link
     Given a <state> petition "My petition" exists
-    And the petition has a ScotParl link "some URL"
+    And the petition has a ScotParl link "https://www.parliament.scot/"
     When I view the petition
-    Then I should see a link called "<copy>" linking to "some URL"
+    Then I should see a link called "<copy>" linking to "https://www.parliament.scot/"
 
     Scenarios:
       | state     | copy                                                                        |

--- a/spec/controllers/admin/completion_date_controller_spec.rb
+++ b/spec/controllers/admin/completion_date_controller_spec.rb
@@ -8,14 +8,14 @@ RSpec.describe Admin::CompletionDateController, type: :controller, admin: true d
   describe "not logged in" do
     describe "GET /admin/petitions/:petition_id/completion-date" do
       it "redirects to the login page" do
-        get :show, params: { petition_id: petition.id }
+        get :show, params: { petition_id: petition.to_param }
         expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/login")
       end
     end
 
     describe "PATCH /admin/petitions/:petition_id/completion-date" do
       it "redirects to the login page" do
-        patch :update, params: { petition_id: petition.id }
+        patch :update, params: { petition_id: petition.to_param }
         expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/login")
       end
     end
@@ -27,14 +27,14 @@ RSpec.describe Admin::CompletionDateController, type: :controller, admin: true d
 
     describe "GET /admin/petitions/:petition_id/completion-date" do
       it "redirects to the login page" do
-        get :show, params: { petition_id: petition.id }
+        get :show, params: { petition_id: petition.to_param }
         expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/profile/#{user.id}/edit")
       end
     end
 
     describe "PATCH /admin/petitions/:petition_id/completion-date" do
       it "redirects to edit profile page" do
-        patch :update, params: { petition_id: petition.id }
+        patch :update, params: { petition_id: petition.to_param }
         expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/profile/#{user.id}/edit")
       end
     end
@@ -82,13 +82,30 @@ RSpec.describe Admin::CompletionDateController, type: :controller, admin: true d
       end
 
       it "redirects to the petition page" do
-        patch :update, params: { petition_id: petition.id, petition: params }
+        patch :update, params: { petition_id: petition.to_param, petition: params }
         expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/petitions/#{petition.to_param}")
       end
 
       it "displays a notice" do
-        patch :update, params: { petition_id: petition.id, petition: params }
+        patch :update, params: { petition_id: petition.to_param, petition: params }
         expect(flash[:notice]).to eq("The completion date was successfully updated")
+      end
+
+      context "when the update fails" do
+        before do
+          expect(Petition).to receive(:find).with(petition.to_param).and_return(petition)
+          expect(petition).to receive(:update).and_return(false)
+        end
+
+        it "renders the petition page" do
+          patch :update, params: { petition_id: petition.to_param, petition: params }
+          expect(response).to have_rendered("admin/petitions/show")
+        end
+
+        it "displays an alert" do
+          patch :update, params: { petition_id: petition.to_param, petition: params }
+          expect(flash[:alert]).to eq("Petition could not be updated - please check the form for errors")
+        end
       end
     end
   end

--- a/spec/controllers/admin/moderation_controller_spec.rb
+++ b/spec/controllers/admin/moderation_controller_spec.rb
@@ -27,6 +27,26 @@ RSpec.describe Admin::ModerationController, type: :controller, admin: true do
         patch :update, params: params
       end
 
+      context "when no moderation is selected" do
+        let(:petition) { FactoryBot.create(:pending_petition) }
+
+        before do
+          do_patch moderation: ""
+        end
+
+        it "returns 200 OK" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "renders the :show template" do
+          expect(response).to render_template("admin/petitions/show")
+        end
+
+        it "displays an alert" do
+          expect(flash[:alert]).to eq("Petition could not be updated - please check the form for errors")
+        end
+      end
+
       context "when the petition is not validated" do
         let(:petition) { FactoryBot.create(:pending_petition) }
 

--- a/spec/controllers/admin/notes_controller_spec.rb
+++ b/spec/controllers/admin/notes_controller_spec.rb
@@ -186,6 +186,30 @@ RSpec.describe Admin::NotesController, type: :controller, admin: true do
           }.not_to raise_error
         end
       end
+
+      context "when updating the notes fails for an unknown reason" do
+        let(:note) { FactoryBot.build(:note, details: "", petition: petition) }
+
+        before do
+          expect(Petition).to receive(:find).with(petition.to_param).and_return(petition)
+          expect(petition).to receive(:note).and_return(note)
+          expect(note).to receive(:update).and_return(false)
+
+          patch :update, params: { petition_id: petition.to_param, note: { details: "" } }
+        end
+
+        it "returns 200 OK" do
+          expect(response).to have_http_status(:ok)
+        end
+
+        it "renders the :show template" do
+          expect(response).to render_template("admin/petitions/show")
+        end
+
+        it "displays an alert" do
+          expect(flash[:alert]).to eq("Petition could not be updated - please contact support")
+        end
+      end
     end
   end
 end

--- a/spec/controllers/admin/petition_tags_controller_spec.rb
+++ b/spec/controllers/admin/petition_tags_controller_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe Admin::PetitionTagsController, type: :controller, admin: true do
         it "renders the :show template" do
           expect(response).to render_template("admin/petitions/show")
         end
+
+        it "displays an alert" do
+          expect(flash[:alert]).to eq("Petition could not be updated - please contact support")
+        end
       end
 
       context "and the params are valid" do

--- a/spec/controllers/admin/petition_topics_controller_spec.rb
+++ b/spec/controllers/admin/petition_topics_controller_spec.rb
@@ -69,6 +69,10 @@ RSpec.describe Admin::PetitionTopicsController, type: :controller, admin: true d
         it "renders the :show template" do
           expect(response).to render_template("admin/petitions/show")
         end
+
+        it "displays an alert" do
+          expect(flash[:alert]).to eq("Petition could not be updated - please contact support")
+        end
       end
 
       context "and the params are empty" do

--- a/spec/controllers/admin/schedule_debate_controller_spec.rb
+++ b/spec/controllers/admin/schedule_debate_controller_spec.rb
@@ -197,30 +197,25 @@ RSpec.describe Admin::ScheduleDebateController, type: :controller, admin: true d
             end
           end
 
-          describe 'with invalid params' do
+          describe "with an invalid date" do
+            let(:scheduled_debate_date_attributes) do
+              { scheduled_debate_date: '9999-99-99' }
+            end
+
             before do
-              # NOTE this can't fail as there's no validation
-              allow_any_instance_of(Petition).to receive(:valid?) do |receiver|
-                receiver.errors.add(:base, 'this is all messed up')
-                false
-              end
+              do_patch
             end
 
-            it 're-renders the petitions/show template' do
-              do_patch
-              expect(response).to be_successful
-              expect(response).to render_template('petitions/show')
+            it "returns 200 OK" do
+              expect(response).to have_http_status(:ok)
             end
 
-            it 'leaves the in-memory instance with errors' do
-              do_patch
-              expect(assigns(:petition).errors).to be_present
+            it "renders the :show template" do
+              expect(response).to render_template("admin/petitions/show")
             end
 
-            it 'does not store the supplied debate scheduled date in the db' do
-              do_patch
-              petition.reload
-              expect(petition.scheduled_debate_date).to be_nil
+            it "displays an alert" do
+              expect(flash[:alert]).to eq("Petition could not be updated - please check the form for errors")
             end
           end
         end
@@ -345,30 +340,25 @@ RSpec.describe Admin::ScheduleDebateController, type: :controller, admin: true d
             end
           end
 
-          describe 'with invalid params' do
+          describe "with an invalid date" do
+            let(:scheduled_debate_date_attributes) do
+              { scheduled_debate_date: '9999-99-99' }
+            end
+
             before do
-              # NOTE this can't fail as there's no validation
-              allow_any_instance_of(Petition).to receive(:valid?) do |receiver|
-                receiver.errors.add(:base, 'this is all messed up')
-                false
-              end
+              do_patch
             end
 
-            it 're-renders the petitions/show template' do
-              do_patch
-              expect(response).to be_successful
-              expect(response).to render_template('petitions/show')
+            it "returns 200 OK" do
+              expect(response).to have_http_status(:ok)
             end
 
-            it 'leaves the in-memory instance with errors' do
-              do_patch
-              expect(assigns(:petition).errors).to be_present
+            it "renders the :show template" do
+              expect(response).to render_template("admin/petitions/show")
             end
 
-            it 'does not store the supplied debate scheduled date in the db' do
-              do_patch
-              petition.reload
-              expect(petition.scheduled_debate_date).to be_nil
+            it "displays an alert" do
+              expect(flash[:alert]).to eq("Petition could not be updated - please check the form for errors")
             end
           end
         end

--- a/spec/controllers/admin/scot_parl_link_controller_spec.rb
+++ b/spec/controllers/admin/scot_parl_link_controller_spec.rb
@@ -7,14 +7,14 @@ RSpec.describe Admin::ScotParlLinkController, type: :controller, admin: true do
   describe "not logged in" do
     describe "GET /show" do
       it "redirects to the login page" do
-        get :show, params: { petition_id: petition.id }
+        get :show, params: { petition_id: petition.to_param }
         expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/login")
       end
     end
 
     describe "PATCH /update" do
       it "redirects to the login page" do
-        patch :update, params: { petition_id: petition.id }
+        patch :update, params: { petition_id: petition.to_param }
         expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/login")
       end
     end
@@ -26,14 +26,14 @@ RSpec.describe Admin::ScotParlLinkController, type: :controller, admin: true do
 
     describe "GET /show" do
       it "redirects to edit profile page" do
-        get :show, params: { petition_id: petition.id }
+        get :show, params: { petition_id: petition.to_param }
         expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/profile/#{user.id}/edit")
       end
     end
 
     describe "PATCH /update" do
       it "redirects to edit profile page" do
-        patch :update, params: { petition_id: petition.id }
+        patch :update, params: { petition_id: petition.to_param }
         expect(response).to redirect_to("https://moderate.petitions.parliament.scot/admin/profile/#{user.id}/edit")
       end
     end
@@ -45,12 +45,12 @@ RSpec.describe Admin::ScotParlLinkController, type: :controller, admin: true do
 
     describe "GET /show" do
       it "fetches the requested petition" do
-        get :show, params: { petition_id: petition.id }
+        get :show, params: { petition_id: petition.to_param }
         expect(assigns(:petition)).to eq petition
       end
 
       it "responds successfully and renders the petitions/show template" do
-        get :show, params: { petition_id: petition.id }
+        get :show, params: { petition_id: petition.to_param }
         expect(response).to be_successful
         expect(response).to render_template("petitions/show")
       end
@@ -65,7 +65,7 @@ RSpec.describe Admin::ScotParlLinkController, type: :controller, admin: true do
       end
 
       before do
-        patch :update, params: { petition_id: petition.id, petition: attributes }
+        patch :update, params: { petition_id: petition.to_param, petition: attributes }
       end
 
       it "fetches the requested petition" do
@@ -94,6 +94,23 @@ RSpec.describe Admin::ScotParlLinkController, type: :controller, admin: true do
         }.to change {
           petition.scot_parl_link_gd
         }.from(nil).to(a_string_matching("www.parlamaid-alba.scot"))
+      end
+
+      context "when the update fails" do
+        before do
+          expect(Petition).to receive(:find).with(petition.to_param).and_return(petition)
+          expect(petition).to receive(:update).and_return(false)
+        end
+
+        it "renders the petition page" do
+          patch :update, params: { petition_id: petition.to_param, petition: attributes }
+          expect(response).to have_rendered("admin/petitions/show")
+        end
+
+        it "displays an alert" do
+          patch :update, params: { petition_id: petition.to_param, petition: attributes }
+          expect(flash[:alert]).to eq("Petition could not be updated - please check the form for errors")
+        end
       end
     end
   end

--- a/spec/controllers/admin/take_down_controller_spec.rb
+++ b/spec/controllers/admin/take_down_controller_spec.rb
@@ -228,6 +228,11 @@ RSpec.describe Admin::TakeDownController, type: :controller, admin: true do
             expect(response).to be_successful
             expect(response).to render_template 'petitions/show'
           end
+
+          it "displays an alert" do
+            expect(response).to be_successful
+            expect(flash[:alert]).to eq("Petition could not be taken down - please check the form for errors")
+          end
         end
       end
 


### PR DESCRIPTION
As the number of actions on the petition page has increased any forms with errors are being pushed down the page. This results in moderators not seeing that there was an error and relying on them seeing there's no green notice and its significance. Adding red alerts when the update fails makes it easier for the moderators to see something has gone wrong and where a failure shouldn't happen we advise them to contact us.