### PR TITLE
Move public flash messages to locale files

### DIFF
--- a/app/controllers/concerns/flash_i18n.rb
+++ b/app/controllers/concerns/flash_i18n.rb
@@ -18,11 +18,17 @@ module FlashI18n
   end
 
   def translate_flash(key)
+    if admin_request?
+      scope = :"admin.flash"
+    else
+      scope = :"ui.flash"
+    end
+
     if Array === key
       options = key.extract_options!
-      I18n.t(key.first, { scope: :"admin.flash" }.merge(options))
+      I18n.t(key.first, { scope: scope }.merge(options))
     elsif Symbol === key
-      I18n.t(key, scope: :"admin.flash")
+      I18n.t(key, scope: scope)
     else
       key
     end

--- a/app/controllers/localized_controller.rb
+++ b/app/controllers/localized_controller.rb
@@ -1,4 +1,6 @@
 class LocalizedController < ApplicationController
+  include FlashI18n
+
   if ENV['TRANSLATION_ENABLED'].present?
     before_action do
       Language.reload_translations

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -1,15 +1,18 @@
 class SignaturesController < LocalizedController
   before_action :retrieve_petition, only: [:new, :confirm, :create, :thank_you]
   before_action :retrieve_signature, only: [:verify, :unsubscribe, :signed]
+
+  # Verify petition is in a valid state before processing signature
+  before_action :redirect_to_petition_page_if_rejected, only: [:new, :confirm, :create, :thank_you, :verify, :signed]
+  before_action :redirect_to_petition_page_if_completed, only: [:new, :confirm, :create, :thank_you, :verify, :signed]
+  before_action :redirect_to_petition_page_if_closed, only: [:new, :confirm, :create, :thank_you]
+  before_action :redirect_to_petition_page_if_closed_for_signing, only: [:verify, :signed]
+
   before_action :build_signature, only: [:new, :confirm, :create]
   before_action :expire_signed_tokens, only: [:verify]
   before_action :verify_token, only: [:verify]
   before_action :verify_signed_token, only: [:signed]
   before_action :verify_unsubscribe_token, only: [:unsubscribe]
-  before_action :redirect_to_petition_page_if_rejected, only: [:new, :confirm, :create, :thank_you, :verify, :signed]
-  before_action :redirect_to_petition_page_if_closed, only: [:new, :confirm, :create, :thank_you]
-  before_action :redirect_to_petition_page_if_closed_for_signing, only: [:verify, :signed]
-  before_action :redirect_to_petition_page_if_completed, only: [:new, :confirm, :create, :thank_you]
   before_action :do_not_cache
 
   rescue_from ActiveRecord::RecordNotUnique do |exception|

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -164,25 +164,25 @@ class SignaturesController < LocalizedController
 
   def redirect_to_petition_page_if_rejected
     if @petition.rejected?
-      redirect_to petition_url(@petition), notice: "Sorry, you can't sign petitions that have been rejected"
+      redirect_to petition_url(@petition), notice: :cant_sign_rejected
     end
   end
 
   def redirect_to_petition_page_if_closed
     if @petition.closed? || Site.signature_collection_disabled?
-      redirect_to petition_url(@petition), notice: "Sorry, you can't sign petitions that have been closed"
+      redirect_to petition_url(@petition), notice: :cant_sign_closed
     end
   end
 
   def redirect_to_petition_page_if_closed_for_signing
     if @petition.closed_for_signing? || Site.signature_collection_disabled?
-      redirect_to petition_url(@petition), notice: "Sorry, you can't sign petitions that have been closed"
+      redirect_to petition_url(@petition), notice: :cant_sign_closed
     end
   end
 
   def redirect_to_petition_page_if_completed
     if @petition.completed?
-      redirect_to petition_url(@petition), notice: "Sorry, you can't sign petitions that have been completed"
+      redirect_to petition_url(@petition), notice: :cant_sign_completed
     end
   end
 

--- a/app/controllers/signatures_controller.rb
+++ b/app/controllers/signatures_controller.rb
@@ -7,6 +7,7 @@ class SignaturesController < LocalizedController
   before_action :redirect_to_petition_page_if_completed, only: [:new, :confirm, :create, :thank_you, :verify, :signed]
   before_action :redirect_to_petition_page_if_closed, only: [:new, :confirm, :create, :thank_you]
   before_action :redirect_to_petition_page_if_closed_for_signing, only: [:verify, :signed]
+  before_action :redirect_to_petition_page_if_paused, only: [:new, :confirm, :create, :thank_you, :verify, :signed]
 
   before_action :build_signature, only: [:new, :confirm, :create]
   before_action :expire_signed_tokens, only: [:verify]
@@ -172,13 +173,13 @@ class SignaturesController < LocalizedController
   end
 
   def redirect_to_petition_page_if_closed
-    if @petition.closed? || Site.signature_collection_disabled?
+    if @petition.closed?
       redirect_to petition_url(@petition), notice: :cant_sign_closed
     end
   end
 
   def redirect_to_petition_page_if_closed_for_signing
-    if @petition.closed_for_signing? || Site.signature_collection_disabled?
+    if @petition.closed_for_signing?
       redirect_to petition_url(@petition), notice: :cant_sign_closed
     end
   end
@@ -186,6 +187,12 @@ class SignaturesController < LocalizedController
   def redirect_to_petition_page_if_completed
     if @petition.completed?
       redirect_to petition_url(@petition), notice: :cant_sign_completed
+    end
+  end
+
+  def redirect_to_petition_page_if_paused
+    if Site.signature_collection_disabled?
+      redirect_to petition_url(@petition), notice: :cant_sign_paused
     end
   end
 

--- a/app/controllers/sponsors_controller.rb
+++ b/app/controllers/sponsors_controller.rb
@@ -1,5 +1,6 @@
 class SponsorsController < SignaturesController
   skip_before_action :redirect_to_petition_page_if_rejected
+  skip_before_action :redirect_to_petition_page_if_completed
   skip_before_action :redirect_to_petition_page_if_closed
   skip_before_action :redirect_to_petition_page_if_closed_for_signing
 

--- a/app/views/petitions/gathering_support.html.erb
+++ b/app/views/petitions/gathering_support.html.erb
@@ -1,5 +1,7 @@
-<h1><%= t(:"ui.petitions.gathering_support.heading") %></h1>
+<section aria-labelledby="page-heading">
+  <h1 id="page-heading"><%= t(:"ui.petitions.gathering_support.heading") %></h1>
 
-<p><%= t(:"ui.petitions.gathering_support.supporters_needed_html", creator_name: @petition.creator.name, n_sponsors: Site.minimum_number_of_sponsors, standards_link: petition_standards_link) %></p>
+  <p><%= t(:"ui.petitions.gathering_support.supporters_needed_html", creator_name: @petition.creator.name, n_sponsors: Site.minimum_number_of_sponsors, standards_link: petition_standards_link) %></p>
 
-<p><%= t(:"ui.petitions.gathering_support.try_again_later") %></p>
+  <p><%= t(:"ui.petitions.gathering_support.try_again_later") %></p>
+</section>

--- a/app/views/petitions/moderation_info.html.erb
+++ b/app/views/petitions/moderation_info.html.erb
@@ -1,9 +1,11 @@
-<h1><%= t(:"ui.petitions.moderation_info.heading") %></h1>
+<section aria-labelledby="page-heading">
+  <h1 id="page-heading"><%= t(:"ui.petitions.moderation_info.heading") %></h1>
 
-<% if Site.collecting_sponsors? %>
-  <p><%= t(:"ui.petitions.moderation_info.min_supporters_reached", min_supporters: Site.minimum_number_of_sponsors, creator_name: @petition.creator.name) %></p>
-<% end %>
+  <% if Site.collecting_sponsors? %>
+    <p><%= t(:"ui.petitions.moderation_info.min_supporters_reached", min_supporters: Site.minimum_number_of_sponsors, creator_name: @petition.creator.name) %></p>
+  <% end %>
 
-<p><%= t(:"ui.petitions.moderation_info.checking_standards_html", standards_link: petition_standards_link) %></p>
+  <p><%= t(:"ui.petitions.moderation_info.checking_standards_html", standards_link: petition_standards_link) %></p>
 
-<p><%= t(:"ui.petitions.moderation_info.try_again_later") %></p>
+  <p><%= t(:"ui.petitions.moderation_info.try_again_later") %></p>
+</section>

--- a/config/locales/ui.en-GB.yml
+++ b/config/locales/ui.en-GB.yml
@@ -1,6 +1,10 @@
 ---
 en-GB:
   ui:
+    flash:
+      cant_sign_rejected: "Sorry, you can't sign petitions that have been rejected"
+      cant_sign_closed: "Sorry, you can't sign petitions that have been closed"
+      cant_sign_completed: "Sorry, you can't sign petitions that have been completed"
     holding_page:
       body_html: |-
         <h1 id="page-heading">A new petitions site is coming on 6 April</h1>

--- a/config/locales/ui.en-GB.yml
+++ b/config/locales/ui.en-GB.yml
@@ -5,6 +5,7 @@ en-GB:
       cant_sign_rejected: "Sorry, you can't sign petitions that have been rejected"
       cant_sign_closed: "Sorry, you can't sign petitions that have been closed"
       cant_sign_completed: "Sorry, you can't sign petitions that have been completed"
+      cant_sign_paused: "Sorry, you can't sign petitions at the moment"
     holding_page:
       body_html: |-
         <h1 id="page-heading">A new petitions site is coming on 6 April</h1>

--- a/config/locales/ui.en-GB.yml
+++ b/config/locales/ui.en-GB.yml
@@ -3,8 +3,8 @@ en-GB:
   ui:
     flash:
       cant_sign_rejected: "Sorry, you can't sign petitions that have been rejected"
-      cant_sign_closed: "Sorry, you can't sign petitions that have been closed"
-      cant_sign_completed: "Sorry, you can't sign petitions that have been completed"
+      cant_sign_closed: "Sorry, you can't sign petitions that are under consideration"
+      cant_sign_completed: "Sorry, you can't sign petitions that have been closed"
       cant_sign_paused: "Sorry, you can't sign petitions at the moment"
     holding_page:
       body_html: |-

--- a/config/locales/ui.gd-GB.yml
+++ b/config/locales/ui.gd-GB.yml
@@ -1,6 +1,10 @@
 ---
 gd-GB:
   ui:
+    flash:
+      cant_sign_rejected: "Sorry, you can't sign petitions that have been rejected"
+      cant_sign_closed: "Sorry, you can't sign petitions that have been closed"
+      cant_sign_completed: "Sorry, you can't sign petitions that have been completed"
     holding_page:
       body_html: |-
         <h1 id="page-heading">A new petitions site is coming on 6 April</h1>

--- a/config/locales/ui.gd-GB.yml
+++ b/config/locales/ui.gd-GB.yml
@@ -5,6 +5,7 @@ gd-GB:
       cant_sign_rejected: "Sorry, you can't sign petitions that have been rejected"
       cant_sign_closed: "Sorry, you can't sign petitions that have been closed"
       cant_sign_completed: "Sorry, you can't sign petitions that have been completed"
+      cant_sign_paused: "Sorry, you can't sign petitions at the moment"
     holding_page:
       body_html: |-
         <h1 id="page-heading">A new petitions site is coming on 6 April</h1>

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -121,7 +121,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
       end
 
       it "redirects to the petition page" do
@@ -295,7 +295,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
       end
 
       it "redirects to the petition page" do
@@ -592,7 +592,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
       end
 
       it "redirects to the petition page" do
@@ -735,7 +735,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
       end
 
       it "doesn't create a signature" do
@@ -977,7 +977,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
       end
 
       it "redirects to the petition page" do
@@ -1209,7 +1209,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
       end
 
       it "redirects to the petition page" do

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -38,12 +38,16 @@ RSpec.describe SignaturesController, type: :controller do
         expect(assigns[:petition]).to eq(petition)
       end
 
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+      end
+
       it "redirects to the petition page" do
         expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
-    context "when the petition is rejected" do
+    context "when the petition was rejected" do
       let(:petition) { FactoryBot.create(:rejected_petition) }
 
       before do
@@ -52,6 +56,30 @@ RSpec.describe SignaturesController, type: :controller do
 
       it "assigns the @petition instance variable" do
         expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been rejected")
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
+      end
+    end
+
+    context "when the petition has been completed" do
+      let(:petition) { FactoryBot.create(:completed_petition) }
+
+      before do
+        get :new, params: { petition_id: petition.id }
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
       end
 
       it "redirects to the petition page" do
@@ -90,6 +118,10 @@ RSpec.describe SignaturesController, type: :controller do
         expect(Site).to receive(:signature_collection_disabled?).and_return(true)
 
         get :new, params: { petition_id: petition.id }
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
       end
 
       it "redirects to the petition page" do
@@ -140,12 +172,16 @@ RSpec.describe SignaturesController, type: :controller do
         expect(assigns[:petition]).to eq(petition)
       end
 
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+      end
+
       it "redirects to the petition page" do
         expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
-    context "when the petition is rejected" do
+    context "when the petition was rejected" do
       let(:petition) { FactoryBot.create(:rejected_petition) }
 
       before do
@@ -154,6 +190,30 @@ RSpec.describe SignaturesController, type: :controller do
 
       it "assigns the @petition instance variable" do
         expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been rejected")
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
+      end
+    end
+
+    context "when the petition has been completed" do
+      let(:petition) { FactoryBot.create(:completed_petition) }
+
+      before do
+        post :confirm, params: { petition_id: petition.id, signature: params }
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
       end
 
       it "redirects to the petition page" do
@@ -234,6 +294,10 @@ RSpec.describe SignaturesController, type: :controller do
         post :confirm, params: { petition_id: petition.id, signature: params }
       end
 
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+      end
+
       it "redirects to the petition page" do
         expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
@@ -282,12 +346,16 @@ RSpec.describe SignaturesController, type: :controller do
         expect(assigns[:petition]).to eq(petition)
       end
 
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+      end
+
       it "redirects to the petition page" do
         expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
     end
 
-    context "when the petition is rejected" do
+    context "when the petition was rejected" do
       let(:petition) { FactoryBot.create(:rejected_petition) }
 
       before do
@@ -296,6 +364,30 @@ RSpec.describe SignaturesController, type: :controller do
 
       it "assigns the @petition instance variable" do
         expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been rejected")
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
+      end
+    end
+
+    context "when the petition has been completed" do
+      let(:petition) { FactoryBot.create(:completed_petition) }
+
+      before do
+        post :confirm, params: { petition_id: petition.id, signature: params }
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
       end
 
       it "redirects to the petition page" do
@@ -499,6 +591,10 @@ RSpec.describe SignaturesController, type: :controller do
         }
       end
 
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+      end
+
       it "redirects to the petition page" do
         expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
@@ -539,6 +635,26 @@ RSpec.describe SignaturesController, type: :controller do
 
       it "sets the flash :notice message" do
         expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been rejected")
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
+      end
+    end
+
+    context "when the petition was completed" do
+      let(:petition) { FactoryBot.create(:completed_petition) }
+
+      before do
+        get :thank_you, params: { petition_id: petition.id }
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
       end
 
       it "redirects to the petition page" do
@@ -616,6 +732,10 @@ RSpec.describe SignaturesController, type: :controller do
 
       it "redirects to the petition page" do
         expect(response).to redirect_to("/petitions/#{petition.to_param}")
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
       end
 
       it "doesn't create a signature" do
@@ -697,6 +817,31 @@ RSpec.describe SignaturesController, type: :controller do
 
       it "sets the flash :notice message" do
         expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been rejected")
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
+      end
+    end
+
+    context "when the petition has been completed" do
+      let(:petition) { FactoryBot.create(:completed_petition) }
+      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+      before do
+        get :verify, params: { id: signature.id, token: signature.perishable_token }
+      end
+
+      it "assigns the @signature instance variable" do
+        expect(assigns[:signature]).to eq(signature)
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
       end
 
       it "redirects to the petition page" do
@@ -831,6 +976,10 @@ RSpec.describe SignaturesController, type: :controller do
         get :verify, params: { id: signature.id, token: signature.perishable_token }
       end
 
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+      end
+
       it "redirects to the petition page" do
         expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
@@ -911,6 +1060,35 @@ RSpec.describe SignaturesController, type: :controller do
         expect(assigns[:petition]).to eq(petition)
       end
 
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been rejected")
+      end
+
+      it "redirects to the petition page" do
+        expect(response).to redirect_to("/petitions/#{petition.to_param}")
+      end
+    end
+
+    context "when the petition has been completed" do
+      let(:petition) { FactoryBot.create(:completed_petition) }
+      let(:signature) { FactoryBot.create(:pending_signature, petition: petition) }
+
+      before do
+        get :signed, params: { id: signature.id }
+      end
+
+      it "assigns the @signature instance variable" do
+        expect(assigns[:signature]).to eq(signature)
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
+      end
+
       it "redirects to the petition page" do
         expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
@@ -930,6 +1108,10 @@ RSpec.describe SignaturesController, type: :controller do
 
       it "assigns the @petition instance variable" do
         expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
       end
 
       it "redirects to the petition page" do
@@ -1026,6 +1208,10 @@ RSpec.describe SignaturesController, type: :controller do
         get :signed, params: { id: signature.id }
       end
 
+      it "sets the flash :notice message" do
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+      end
+
       it "redirects to the petition page" do
         expect(response).to redirect_to("/petitions/#{petition.to_param}")
       end
@@ -1089,6 +1275,31 @@ RSpec.describe SignaturesController, type: :controller do
 
     context "when the petition was rejected" do
       let(:petition) { FactoryBot.create(:rejected_petition) }
+      let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
+
+      before do
+        get :unsubscribe, params: { id: signature.id, token: signature.unsubscribe_token }
+      end
+
+      it "assigns the @signature instance variable" do
+        expect(assigns[:signature]).to eq(signature)
+      end
+
+      it "assigns the @petition instance variable" do
+        expect(assigns[:petition]).to eq(petition)
+      end
+
+      it "unsubscribes from email updates" do
+        expect(assigns[:signature].notify_by_email).to eq(false)
+      end
+
+      it "renders the signatures/unsubscribe template" do
+        expect(response).to render_template("signatures/unsubscribe")
+      end
+    end
+
+    context "when the petition has been completed" do
+      let(:petition) { FactoryBot.create(:completed_petition) }
       let(:signature) { FactoryBot.create(:validated_signature, petition: petition) }
 
       before do

--- a/spec/controllers/signatures_controller_spec.rb
+++ b/spec/controllers/signatures_controller_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that are under consideration")
       end
 
       it "redirects to the petition page" do
@@ -79,7 +79,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
       end
 
       it "redirects to the petition page" do
@@ -173,7 +173,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that are under consideration")
       end
 
       it "redirects to the petition page" do
@@ -213,7 +213,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
       end
 
       it "redirects to the petition page" do
@@ -347,7 +347,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that are under consideration")
       end
 
       it "redirects to the petition page" do
@@ -387,7 +387,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
       end
 
       it "redirects to the petition page" do
@@ -654,7 +654,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
       end
 
       it "redirects to the petition page" do
@@ -675,7 +675,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that are under consideration")
       end
 
       it "redirects to the petition page" do
@@ -696,7 +696,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that are under consideration")
       end
 
       it "redirects to the petition page" do
@@ -841,7 +841,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
       end
 
       it "redirects to the petition page" do
@@ -866,7 +866,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that are under consideration")
       end
 
       it "redirects to the petition page" do
@@ -1086,7 +1086,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been completed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
       end
 
       it "redirects to the petition page" do
@@ -1111,7 +1111,7 @@ RSpec.describe SignaturesController, type: :controller do
       end
 
       it "sets the flash :notice message" do
-        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that have been closed")
+        expect(flash[:notice]).to eq("Sorry, you can't sign petitions that are under consideration")
       end
 
       it "redirects to the petition page" do

--- a/spec/controllers/sponsors_controller_spec.rb
+++ b/spec/controllers/sponsors_controller_spec.rb
@@ -1,9 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe SponsorsController, type: :controller do
+  let(:signature_collection_disabled?) { false }
+
   before do
     constituency = FactoryBot.create(:constituency, :glasgow_provan)
     allow(Constituency).to receive(:find_by_postcode).with("G340BX").and_return(constituency)
+
+    allow(Site).to receive(:signature_collection_disabled?).and_return(signature_collection_disabled?)
   end
 
   describe "GET /petitions/:petition_id/sponsors/new" do
@@ -121,6 +125,18 @@ RSpec.describe SponsorsController, type: :controller do
 
           it "redirects to the petition moderation info page" do
             expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
+          end
+        end
+
+        context "and signature collection is paused" do
+          let(:signature_collection_disabled?) { true }
+
+          it "sets the flash :notice message" do
+            expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
+          end
+
+          it "redirects to the petition page" do
+            expect(response).to redirect_to("/petitions/#{petition.to_param}")
           end
         end
       end
@@ -279,6 +295,18 @@ RSpec.describe SponsorsController, type: :controller do
 
           it "redirects to the petition moderation info page" do
             expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
+          end
+        end
+
+        context "and signature collection is paused" do
+          let(:signature_collection_disabled?) { true }
+
+          it "sets the flash :notice message" do
+            expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
+          end
+
+          it "redirects to the petition page" do
+            expect(response).to redirect_to("/petitions/#{petition.to_param}")
           end
         end
       end
@@ -573,6 +601,24 @@ RSpec.describe SponsorsController, type: :controller do
             expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
           end
         end
+
+        context "and signature collection is paused" do
+          let(:signature_collection_disabled?) { true }
+
+          before do
+            perform_enqueued_jobs {
+              post :create, params: { petition_id: petition.id, token: petition.sponsor_token, signature: params }
+            }
+          end
+
+          it "sets the flash :notice message" do
+            expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
+          end
+
+          it "redirects to the petition page" do
+            expect(response).to redirect_to("/petitions/#{petition.to_param}")
+          end
+        end
       end
     end
   end
@@ -668,6 +714,18 @@ RSpec.describe SponsorsController, type: :controller do
 
           it "renders the signatures/thank_you template" do
             expect(response).to render_template("signatures/thank_you")
+          end
+        end
+
+        context "and signature collection is paused" do
+          let(:signature_collection_disabled?) { true }
+
+          it "sets the flash :notice message" do
+            expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
+          end
+
+          it "redirects to the petition page" do
+            expect(response).to redirect_to("/petitions/#{petition.to_param}")
           end
         end
       end
@@ -841,6 +899,18 @@ RSpec.describe SponsorsController, type: :controller do
           expect(flash[:notice]).to be_nil
         end
       end
+
+      context "and signature collection is paused" do
+        let(:signature_collection_disabled?) { true }
+
+        it "sets the flash :notice message" do
+          expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
+        end
+
+        it "redirects to the petition page" do
+          expect(response).to redirect_to("/petitions/#{petition.to_param}")
+        end
+      end
     end
 
     context "when the petition is validated" do
@@ -989,6 +1059,18 @@ RSpec.describe SponsorsController, type: :controller do
           expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
         end
       end
+
+      context "and signature collection is paused" do
+        let(:signature_collection_disabled?) { true }
+
+        it "sets the flash :notice message" do
+          expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
+        end
+
+        it "redirects to the petition page" do
+          expect(response).to redirect_to("/petitions/#{petition.to_param}")
+        end
+      end
     end
 
     context "when the petition is sponsored" do
@@ -1090,6 +1172,18 @@ RSpec.describe SponsorsController, type: :controller do
           expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
         end
       end
+
+      context "and signature collection is paused" do
+        let(:signature_collection_disabled?) { true }
+
+        it "sets the flash :notice message" do
+          expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
+        end
+
+        it "redirects to the petition page" do
+          expect(response).to redirect_to("/petitions/#{petition.to_param}")
+        end
+      end
     end
   end
 
@@ -1180,7 +1274,7 @@ RSpec.describe SponsorsController, type: :controller do
         let(:petition) { FactoryBot.create(:"#{state}_petition") }
         let(:signature) { FactoryBot.create(:validated_signature, :just_signed, petition: petition, sponsor: true) }
 
-        context "when the signature has been validated" do
+        context "and the signature has been validated" do
           before do
             session[:signed_tokens] = { signature.id.to_s => signature.signed_token }
             get :signed, params: { id: signature.id }
@@ -1261,9 +1355,21 @@ RSpec.describe SponsorsController, type: :controller do
               expect(response).to render_template("sponsors/signed")
             end
           end
+
+          context "and signature collection is paused" do
+            let(:signature_collection_disabled?) { true }
+
+            it "sets the flash :notice message" do
+              expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
+            end
+
+            it "redirects to the petition page" do
+              expect(response).to redirect_to("/petitions/#{petition.to_param}")
+            end
+          end
         end
 
-        context "when the signature has not been validated" do
+        context "and the signature has not been validated" do
           let(:signature) { FactoryBot.create(:pending_signature, petition: petition, sponsor: true) }
 
           before do
@@ -1272,6 +1378,18 @@ RSpec.describe SponsorsController, type: :controller do
 
           it "redirects to the petition moderation info page" do
             expect(response).to redirect_to("/petitions/#{petition.to_param}/moderation-info")
+          end
+
+          context "and signature collection is paused" do
+            let(:signature_collection_disabled?) { true }
+
+            it "sets the flash :notice message" do
+              expect(flash[:notice]).to eq("Sorry, you can't sign petitions at the moment")
+            end
+
+            it "redirects to the petition page" do
+              expect(response).to redirect_to("/petitions/#{petition.to_param}")
+            end
           end
         end
       end


### PR DESCRIPTION
These messages are rare - the only ones that might possibly be seen without url hacking is someone clicking an old signature verification link or a direct link to the new signature page which is discouraged as someone should read the petition before signing it.