### PR TITLE
Remove 'Committee Note' feature

### DIFF
--- a/app/controllers/admin/petition_details_controller.rb
+++ b/app/controllers/admin/petition_details_controller.rb
@@ -31,7 +31,7 @@ class Admin::PetitionDetailsController < Admin::AdminController
   def petition_params
     params.require(:petition).permit(
       :action, :background, :previous_action, :additional_details, :closed_at, :use_markdown,
-      :committee_note, :special_consideration, creator_attributes: [
+      :special_consideration, creator_attributes: [
         :name, :email, :postcode, contact_attributes: [:address, :phone_number]
       ]
     )

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -151,7 +151,6 @@ class Petition < ActiveRecord::Base
   # Therefore the allowing of blank values is handling in the validtor.
   validates :scheduled_debate_date, date: true
 
-  validates :committee_note, length: { maximum: 800, allow_blank: true }
   validates :open_at, presence: true, if: :open?
   validates :creator, presence: true, unless: :completed?
   validates :state, inclusion: { in: STATES }

--- a/app/views/admin/petitions/_petition_content.html.erb
+++ b/app/views/admin/petitions/_petition_content.html.erb
@@ -2,12 +2,6 @@
 
 <h1><%= @petition.action %></h1>
 
-<% if @petition.committee_note? %>
-  <div class="committee-note">
-    <%= markdown_to_html(@petition.committee_note) %>
-  </div>
-<% end %>
-
 <div class="petition-content">
   <% if @petition.background? %>
     <%= apply_formatting(@petition, :background) %>

--- a/app/views/petitions/_content.html.erb
+++ b/app/views/petitions/_content.html.erb
@@ -14,12 +14,6 @@
     <%= petition.to_param %>: <%= petition.action %>
   <% end %>
 
-  <% if petition.committee_note? %>
-    <div class="committee-note">
-      <%= markdown_to_html(petition.committee_note) %>
-    </div>
-  <% end %>
-
   <% if petition.background? %>
     <div class="background">
       <%= apply_formatting(petition, :background) %>

--- a/app/views/petitions/_petition.json.jbuilder
+++ b/app/views/petitions/_petition.json.jbuilder
@@ -11,7 +11,6 @@ json.attributes do
   json.previous_action petition.previous_action
   json.background_information petition.additional_details
   json.petitioner petition.creator.name
-  json.committee_note petition.committee_note
   json.status petition.status
   json.signature_count petition.signature_count
 

--- a/features/step_definitions/pickle_steps.rb
+++ b/features/step_definitions/pickle_steps.rb
@@ -206,10 +206,6 @@ Given(/^an open petition exists with action: "([^"]*)", additional_details: "([^
   @petition = FactoryBot.create(:open_petition, action: action, additional_details: additional_details)
 end
 
-Given(/^an open petition exists with action: "([^"]*)", committee_note: "([^"]*)"$/) do |action, committee_note|
-  @petition = FactoryBot.create(:open_petition, action: action, committee_note: committee_note)
-end
-
 Then(/^"([^"]*)" should be emailed a link for validating their signature$/) do |address|
   open_last_email_for(address)
   steps %{

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -46,12 +46,6 @@ Feature: Suzie views a petition
     And I should see a link called "http://www.google.com" linking to "http://www.google.com"
     And I should see a link called "bambi@gmail.com" linking to "mailto:bambi@gmail.com"
 
-  Scenario: Suzie views a petition with a Petitions Committee note
-    Given an open petition exists with action: "Defence review", committee_note: "This petition was found to be misleading"
-    When I go to the petition page for "Defence review"
-    Then the markup should be valid
-    And I should see "This petition was found to be misleading"
-
   Scenario: Suzie sees reason for rejection if appropriate
     Given a petition "Please bring back Eldorado" has been rejected with the reason "We like http://www.google.com and bambi@gmail.com"
     When I view the petition

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -197,10 +197,7 @@ RSpec.describe Petition, type: :model do
     it { is_expected.to have_db_column(:previous_action_gd).of_type(:text).with_options(null: true) }
     it { is_expected.to have_db_column(:additional_details_en).of_type(:text).with_options(null: true) }
     it { is_expected.to have_db_column(:additional_details_gd).of_type(:text).with_options(null: true) }
-    it { is_expected.to have_db_column(:committee_note).of_type(:text).with_options(null: true) }
     it { is_expected.to have_db_column(:collect_signatures).of_type(:boolean).with_options(default: false, null: false) }
-
-    it { is_expected.to validate_length_of(:committee_note).is_at_most(800) }
 
     it { is_expected.to validate_presence_of(:state).with_message("State ‘’ not recognised") }
     it { is_expected.not_to allow_value("unknown").for(:state) }

--- a/spec/requests/petition_show_spec.rb
+++ b/spec/requests/petition_show_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe "API request to show a petition", type: :request, show_exceptions: true do
-  let(:petition) { FactoryBot.create :open_petition, committee_note: "This petition action was found to be false" }
+  let(:petition) { FactoryBot.create :open_petition }
   let(:attributes) { json["data"]["attributes"] }
 
   let(:access_control_allow_origin) { response.headers['Access-Control-Allow-Origin'] }
@@ -52,7 +52,6 @@ RSpec.describe "API request to show a petition", type: :request, show_exceptions
           "previous_action" => a_string_matching(petition.previous_action),
           "background_information" => a_string_matching(petition.additional_details),
           "petitioner" => a_string_matching(petition.creator.name),
-          "committee_note" => a_string_matching(petition.committee_note),
           "status" => a_string_matching(petition.status),
           "signature_count" => eq_to(petition.signature_count),
           "opened_at" => a_string_matching(%r[\A\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z\z]),


### PR DESCRIPTION
This has not been localized and isn't currently used so we need to stop using the column in the app before we can add localized columns.