### PR TITLE
Allow ipv6 addresses for feedback messages

### DIFF
--- a/db/migrate/20210418070355_increase_feedback_ip_address_size.rb
+++ b/db/migrate/20210418070355_increase_feedback_ip_address_size.rb
@@ -1,0 +1,9 @@
+class IncreaseFeedbackIpAddressSize < ActiveRecord::Migration[6.1]
+  def up
+    change_column(:feedback, :ip_address, :string, limit: 40)
+  end
+
+  def down
+    change_column(:feedback, :ip_address, :string, limit: 20)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_04_01_125401) do
+ActiveRecord::Schema.define(version: 2021_04_18_070355) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"
@@ -173,7 +173,7 @@ ActiveRecord::Schema.define(version: 2021_04_01_125401) do
     t.string "petition_link_or_title"
     t.string "email"
     t.string "user_agent"
-    t.string "ip_address", limit: 20
+    t.string "ip_address", limit: 40
     t.datetime "created_at"
     t.index ["ip_address"], name: "index_feedback_on_ip_address"
   end

--- a/spec/models/feedback_spec.rb
+++ b/spec/models/feedback_spec.rb
@@ -10,6 +10,8 @@ RSpec.describe Feedback, type: :model do
     it { is_expected.to have_db_column(:petition_link_or_title).of_type(:string) }
     it { is_expected.to have_db_column(:email).of_type(:string) }
     it { is_expected.to have_db_column(:user_agent).of_type(:string) }
+    it { is_expected.to have_db_column(:ip_address).of_type(:string).with_options(limit: 40) }
+    it { is_expected.to have_db_column(:created_at).of_type(:datetime) }
   end
 
   describe "validations" do


### PR DESCRIPTION
The UK site only allows ipv4 so the rate limiting added to feedback messages in alphagov/e-petitions@bd8e8fe breaks on the Welsh site as its CloudFront distribution allows ipv6 addresses.