### PR TITLE
Ensure correct debate state

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -636,7 +636,10 @@ class Petition < ActiveRecord::Base
 
         if at_threshold_for_debate?
           updates << "debate_threshold_reached_at = :now"
-          updates << "debate_state = 'awaiting'"
+
+          if debate_state == 'pending'
+            updates << "debate_state = 'awaiting'"
+          end
         end
       end
 

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -656,19 +656,24 @@ class Petition < ActiveRecord::Base
   end
 
   def decrement_signature_count!(time = Time.current)
-    updates = ""
+    updates = []
 
     if below_threshold_for_debate?
-      updates << "debate_threshold_reached_at = NULL, "
-      updates << "debate_state = 'pending', "
+      updates << "debate_threshold_reached_at = NULL"
+
+      if debate_state == 'awaiting'
+        updates << "debate_state = 'pending'"
+      end
     end
 
     if below_threshold_for_referral?
-      updates << "referral_threshold_reached_at = NULL, "
+      updates << "referral_threshold_reached_at = NULL"
     end
 
-    updates << "signature_count = greatest(signature_count - 1, 1), "
+    updates << "signature_count = greatest(signature_count - 1, 1)"
     updates << "updated_at = :now"
+
+    updates = updates.join(", ")
 
     if update_all([updates, now: time]) > 0
       self.reload

--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -1151,7 +1151,7 @@ class Petition < ActiveRecord::Base
     if scheduled_debate_date?
       scheduled_debate_date > Date.current ? 'scheduled' : 'debated'
     else
-      'awaiting'
+      debate_threshold_reached_at? ? 'awaiting' : 'pending'
     end
   end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -2132,6 +2132,8 @@ RSpec.describe Petition, type: :model do
 
   describe "#decrement_signature_count!" do
     let(:signature_count) { 8 }
+    let(:debate_state) { 'awaiting' }
+
     let(:petition) do
       FactoryBot.create(:open_petition, {
         signature_count: signature_count,
@@ -2139,7 +2141,7 @@ RSpec.describe Petition, type: :model do
         updated_at: 2.days.ago,
         referral_threshold_reached_at: 2.days.ago,
         debate_threshold_reached_at: 2.days.ago,
-        debate_state: 'awaiting'
+        debate_state: debate_state
       })
     end
 
@@ -2184,14 +2186,54 @@ RSpec.describe Petition, type: :model do
         expect(Site).to receive(:threshold_for_debate).and_return(100)
       end
 
-      it "records the time it happened" do
+      it "resets the timestamp" do
         petition.decrement_signature_count!
         expect(petition.debate_threshold_reached_at).to be_nil
       end
 
-      it "sets the debate_state to 'pending'" do
-        petition.decrement_signature_count!
-        expect(petition.debate_state).to eq("pending")
+      context "and a debate has not been scheduled" do
+        let(:debate_state) { "awaiting" }
+
+        it "sets the debate_state to 'pending'" do
+          petition.decrement_signature_count!
+          expect(petition.debate_state).to eq("pending")
+        end
+      end
+
+      context "and a debate has been scheduled" do
+        let(:debate_state) { "scheduled" }
+
+        it "doesn't change debated_state" do
+          expect {
+            petition.decrement_signature_count!
+          }.not_to change {
+            petition.debate_state
+          }.from("scheduled")
+        end
+      end
+
+      context "and a debate has taken place" do
+        let(:debate_state) { "debated" }
+
+        it "doesn't change debated_state" do
+          expect {
+            petition.decrement_signature_count!
+          }.not_to change {
+            petition.debate_state
+          }.from("debated")
+        end
+      end
+
+      context "and a debate has not taken place" do
+        let(:debate_state) { "not_debated" }
+
+        it "doesn't change debated_state" do
+          expect {
+            petition.decrement_signature_count!
+          }.not_to change {
+            petition.debate_state
+          }.from("not_debated")
+        end
       end
     end
   end

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -1803,8 +1803,11 @@ RSpec.describe Petition, type: :model do
 
   describe "#increment_signature_count!" do
     let(:signature_count) { 8 }
+    let(:debate_state) { 'pending' }
+
     let(:petition) do
       FactoryBot.create(:open_petition, {
+        debate_state: debate_state,
         signature_count: signature_count,
         last_signed_at: 2.days.ago,
         updated_at: 2.days.ago,
@@ -1991,28 +1994,90 @@ RSpec.describe Petition, type: :model do
       end
     end
 
-    context "when the signature count crosses the threshold for a debate" do
-      let(:signature_count) { 99 }
+    context "when the petition hasn't been debated" do
+      let(:debate_state) { "pending" }
 
-      before do
-        expect(Site).to receive(:threshold_for_debate).and_return(100)
-        FactoryBot.create(:validated_signature, petition: petition, increment: false)
+      context "when the signature count crosses the threshold for a debate" do
+        let(:signature_count) { 99 }
+
+        before do
+          expect(Site).to receive(:threshold_for_debate).and_return(100)
+          FactoryBot.create(:validated_signature, petition: petition, increment: false)
+        end
+
+        it "records the time it happened" do
+          expect {
+            petition.increment_signature_count!
+          }.to change {
+            petition.debate_threshold_reached_at
+          }.to be_within(1.second).of(Time.current)
+        end
+
+        it "sets the debate_state to 'awaiting'" do
+          expect {
+            petition.increment_signature_count!
+          }.to change {
+            petition.debate_state
+          }.from("pending").to("awaiting")
+        end
       end
+    end
 
-      it "records the time it happened" do
-        expect {
-          petition.increment_signature_count!
-        }.to change {
-          petition.debate_threshold_reached_at
-        }.to be_within(1.second).of(Time.current)
+    context "when the petition is awaiting a debate" do
+      let(:debate_state) { "awaiting" }
+
+      context "when the signature count crosses the threshold for a debate" do
+        let(:signature_count) { 99 }
+
+        before do
+          expect(Site).to receive(:threshold_for_debate).and_return(100)
+          FactoryBot.create(:validated_signature, petition: petition, increment: false)
+        end
+
+        it "records the time it happened" do
+          expect {
+            petition.increment_signature_count!
+          }.to change {
+            petition.debate_threshold_reached_at
+          }.to be_within(1.second).of(Time.current)
+        end
+
+        it "doesn't change debate_state" do
+          expect {
+            petition.increment_signature_count!
+          }.not_to change {
+            petition.debate_state
+          }.from("awaiting")
+        end
       end
+    end
 
-      it "sets the debate_state to 'awaiting'" do
-        expect {
-          petition.increment_signature_count!
-        }.to change {
-          petition.debate_state
-        }.from("pending").to("awaiting")
+    context "when the petition has been debated" do
+      let(:debate_state) { "debated" }
+
+      context "when the signature count crosses the threshold for a debate" do
+        let(:signature_count) { 99 }
+
+        before do
+          expect(Site).to receive(:threshold_for_debate).and_return(100)
+          FactoryBot.create(:validated_signature, petition: petition, increment: false)
+        end
+
+        it "records the time it happened" do
+          expect {
+            petition.increment_signature_count!
+          }.to change {
+            petition.debate_threshold_reached_at
+          }.to be_within(1.second).of(Time.current)
+        end
+
+        it "doesn't change debate_state" do
+          expect {
+            petition.increment_signature_count!
+          }.not_to change {
+            petition.debate_state
+          }.from("debated")
+        end
       end
     end
 

--- a/spec/models/petition_spec.rb
+++ b/spec/models/petition_spec.rb
@@ -970,6 +970,7 @@ RSpec.describe Petition, type: :model do
       context "and the debate date is changed to nil" do
         subject(:petition) {
           FactoryBot.create(:open_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: 2.days.from_now,
             debate_state: "scheduled"
           )
@@ -987,25 +988,27 @@ RSpec.describe Petition, type: :model do
       context "and the debate date is in the future" do
         subject(:petition) {
           FactoryBot.create(:open_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: nil,
-            debate_state: "pending"
+            debate_state: "awaiting"
           )
         }
 
-        it "sets the debate state to 'awaiting'" do
+        it "sets the debate state to 'scheduled'" do
           expect {
             petition.update(scheduled_debate_date: 2.days.from_now)
           }.to change {
             petition.debate_state
-          }.from("pending").to("scheduled")
+          }.from("awaiting").to("scheduled")
         end
       end
 
       context "and the debate date is in the past" do
         subject(:petition) {
           FactoryBot.create(:open_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: nil,
-            debate_state: "pending"
+            debate_state: "awaiting"
           )
         }
 
@@ -1014,15 +1017,16 @@ RSpec.describe Petition, type: :model do
             petition.update(scheduled_debate_date: 2.days.ago)
           }.to change {
             petition.debate_state
-          }.from("pending").to("debated")
+          }.from("awaiting").to("debated")
         end
       end
 
       context "and the debate date is not changed" do
         subject(:petition) {
           FactoryBot.create(:open_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: Date.yesterday,
-            debate_state: "awaiting"
+            debate_state: "scheduled"
           )
         }
 
@@ -1034,12 +1038,87 @@ RSpec.describe Petition, type: :model do
           }
         end
       end
+
+      context "and has not reached the debate threshold" do
+        context "and the debate date is changed to nil" do
+          subject(:petition) {
+            FactoryBot.create(:open_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: 2.days.from_now,
+              debate_state: "scheduled"
+            )
+          }
+
+          it "sets the debate state to 'pending'" do
+            expect {
+              petition.update(scheduled_debate_date: nil)
+            }.to change {
+              petition.debate_state
+            }.from("scheduled").to("pending")
+          end
+        end
+
+        context "and the debate date is in the future" do
+          subject(:petition) {
+            FactoryBot.create(:open_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: nil,
+              debate_state: "pending"
+            )
+          }
+
+          it "sets the debate state to 'scheduled'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.from_now)
+            }.to change {
+              petition.debate_state
+            }.from("pending").to("scheduled")
+          end
+        end
+
+        context "and the debate date is in the past" do
+          subject(:petition) {
+            FactoryBot.create(:open_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: nil,
+              debate_state: "pending"
+            )
+          }
+
+          it "sets the debate state to 'debated'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.ago)
+            }.to change {
+              petition.debate_state
+            }.from("pending").to("debated")
+          end
+        end
+
+        context "and the debate date is not changed" do
+          subject(:petition) {
+            FactoryBot.create(:open_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: Date.yesterday,
+              debate_state: "debated"
+            )
+          }
+
+          it "does not change the debate state" do
+            expect {
+              petition.update(open_at: 5.days.ago)
+            }.not_to change {
+              petition.debate_state
+            }
+          end
+        end
+      end
     end
 
     context "when the petition is closed" do
       context "and the debate date is changed to nil" do
         subject(:petition) {
           FactoryBot.create(:closed_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: 2.days.from_now,
             debate_state: "scheduled"
           )
@@ -1057,6 +1136,7 @@ RSpec.describe Petition, type: :model do
       context "and the debate date is in the future" do
         subject(:petition) {
           FactoryBot.create(:closed_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: nil,
             debate_state: "awaiting"
           )
@@ -1074,6 +1154,7 @@ RSpec.describe Petition, type: :model do
       context "and the debate date is in the past" do
         subject(:petition) {
           FactoryBot.create(:closed_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: nil,
             debate_state: "awaiting"
           )
@@ -1091,8 +1172,9 @@ RSpec.describe Petition, type: :model do
       context "and the debate date is not changed" do
         subject(:petition) {
           FactoryBot.create(:closed_petition,
+            debate_threshold_reached_at: 1.week.ago,
             scheduled_debate_date: Date.yesterday,
-            debate_state: "awaiting"
+            debate_state: "debated"
           )
         }
 
@@ -1102,6 +1184,80 @@ RSpec.describe Petition, type: :model do
           }.not_to change {
             petition.debate_state
           }
+        end
+      end
+
+      context "and has not reached the debate threshold" do
+        context "and the debate date is changed to nil" do
+          subject(:petition) {
+            FactoryBot.create(:closed_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: 2.days.from_now,
+              debate_state: "scheduled"
+            )
+          }
+
+          it "sets the debate state to 'pending'" do
+            expect {
+              petition.update(scheduled_debate_date: nil)
+            }.to change {
+              petition.debate_state
+            }.from("scheduled").to("pending")
+          end
+        end
+
+        context "and the debate date is in the future" do
+          subject(:petition) {
+            FactoryBot.create(:closed_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: nil,
+              debate_state: "pending"
+            )
+          }
+
+          it "sets the debate state to 'scheduled'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.from_now)
+            }.to change {
+              petition.debate_state
+            }.from("pending").to("scheduled")
+          end
+        end
+
+        context "and the debate date is in the past" do
+          subject(:petition) {
+            FactoryBot.create(:closed_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: nil,
+              debate_state: "pending"
+            )
+          }
+
+          it "sets the debate state to 'debated'" do
+            expect {
+              petition.update(scheduled_debate_date: 2.days.ago)
+            }.to change {
+              petition.debate_state
+            }.from("pending").to("debated")
+          end
+        end
+
+        context "and the debate date is not changed" do
+          subject(:petition) {
+            FactoryBot.create(:closed_petition,
+              debate_threshold_reached_at: nil,
+              scheduled_debate_date: Date.yesterday,
+              debate_state: "debated"
+            )
+          }
+
+          it "does not change the debate state" do
+            expect {
+              petition.update(open_at: 5.days.ago)
+            }.not_to change {
+              petition.debate_state
+            }
+          end
         end
       end
     end


### PR DESCRIPTION
If a petition has been scheduled for a debate, has been debated, or a decision to not debate it has been taken then don't reset the `debate_state` column to an incorrect value.