### PR TITLE
Set timeouts for deployment phases

### DIFF
--- a/lib/package_builder/config/appspec.yml
+++ b/lib/package_builder/config/appspec.yml
@@ -8,12 +8,16 @@ hooks:
   ApplicationStop:
     - location: scripts/application_stop
       runas: root
+      timeout: 60
   BeforeInstall:
     - location: scripts/before_install
       runas: root
+      timeout: 60
   AfterInstall:
     - location: scripts/after_install
       runas: root
+      timeout: 900
   ApplicationStart:
     - location: scripts/application_start
       runas: root
+      timeout: 60


### PR DESCRIPTION
Only the AfterInstall phase takes any appreciable amount of time so reduce the timeouts to one minute. The AfterInstall phase is left at 15 minutes to give us time to see what happened and prevent EC2 creating new instances every few minutes.