### PR TITLE
Add backwards compatibility for API

### DIFF
--- a/app/controllers/petitions_controller.rb
+++ b/app/controllers/petitions_controller.rb
@@ -127,7 +127,15 @@ class PetitionsController < LocalizedController
 
   def redirect_to_valid_state
     if state_present? && !valid_state?
-      redirect_to petitions_url(search_params(state: :all))
+      redirect_to valid_petitions_url
+    end
+  end
+
+  def valid_petitions_url
+    if sanitized_state == :collecting_signatures
+      petitions_url(state: :under_consideration, format: :json)
+    else
+      petitions_url(search_params(state: :all))
     end
   end
 

--- a/spec/requests/petitions_list_spec.rb
+++ b/spec/requests/petitions_list_spec.rb
@@ -82,6 +82,12 @@ RSpec.describe "API request to list petitions", type: :request, show_exceptions:
       expect(links).to include("next" => nil)
     end
 
+    it "redirects to under_consideration if the provided state is collecting_signatures" do
+      get "/petitions.json?state=collecting_signatures"
+
+      expect(response).to redirect_to('/petitions.json?state=under_consideration')
+    end
+
     it "redirects to all petitions if the provided state isn't valid" do
       get "/petitions.json?count=2&page=2&state=rejected"
 


### PR DESCRIPTION
State "collecting signatures" no longer exists, so if someone depends on the API and doesn't change it, it will still work and redirect them to "under consideration" which is the equivalent state now.