### PR TITLE
Don't try to schedule removed job

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -33,10 +33,6 @@ every :day, at: '3.30am' do
 	rake "spets:petitions:update_statistics", output: nil
 end
 
-every :day, at: '7.00am' do
-  rake "spets:petitions:close", output: nil
-end
-
 every :day, at: '7.10am' do
   rake "notify:cleanup", output: nil
 end

--- a/lib/tasks/petitions.rake
+++ b/lib/tasks/petitions.rake
@@ -1,13 +1,5 @@
 namespace :spets do
   namespace :petitions do
-    desc "Add a task to the queue to close petitions at midnight"
-    task :close => :environment do
-      Task.run("spets:petitions:close") do
-        time = Date.tomorrow.beginning_of_day
-        ClosePetitionsJob.set(wait_until: time).perform_later(time.iso8601)
-      end
-    end
-
     desc "Add a task to the queue to validate petition counts"
     task :count => :environment do
       Task.run("spets:petitions:count") do


### PR DESCRIPTION
The ClosePetitionsJob was removed in #161.

NOTE: When deploying to production the changes in #161 we will need to remove any existing queued jobs that have had their job classes removed otherwise Delayed Job will repeatedly try to run them until the max retries limit has been reached.