### PR TITLE
More fixes after UAT 

### DIFF
--- a/app/models/petition.rb
+++ b/app/models/petition.rb
@@ -1151,14 +1151,10 @@ class Petition < ActiveRecord::Base
   end
 
   def state_for_publishing(time)
-    if open_at
-      if closed_at > time
-        collect_signatures? ? OPEN_STATE : CLOSED_STATE
-      else
-        CLOSED_STATE
-      end
-    else
+    if closed_at.nil? || closed_at > time
       collect_signatures? ? OPEN_STATE : CLOSED_STATE
+    else
+      CLOSED_STATE
     end
   end
 

--- a/app/presenters/petition_csv_presenter.rb
+++ b/app/presenters/petition_csv_presenter.rb
@@ -110,7 +110,7 @@ class PetitionCSVPresenter
     when :under_consideration_at
       class_eval <<~RUBY
         def under_consideration_at
-          api_date_format petition.send :closed_at
+          api_date_format petition.send :open_at
         end
       RUBY
     when :closed_at

--- a/app/views/petitions/_closed_petition_show.html.erb
+++ b/app/views/petitions/_closed_petition_show.html.erb
@@ -17,35 +17,23 @@
       </li>
     </ul>
 
-    <% if @petition.referred? %>
-      <section class="referral-notice" aria-labelledby="referral-notice-heading">
-        <h2 id="referral-notice-heading">
-          <% if @petition.completed? %>
-            <%= t(:"ui.petitions.referral_threshold.completed.heading") %>
-          <% else %>
-            <%= t(:"ui.petitions.referral_threshold.referred.heading") %>
-          <% end %>
-        </h2>
-
-        <% if @petition.scot_parl_link? %>
-          <% if @petition.completed? %>
-            <p class="secondary"><%= t(:"ui.petitions.referral_threshold.completed.link_html", link: @petition.scot_parl_link) %></p>
-          <% else %>
-            <p class="secondary"><%= t(:"ui.petitions.referral_threshold.closed.link_html", link: @petition.scot_parl_link) %></p>
-          <% end %>
-        <% end %>
-      </section>
-    <% else %>
-      <section class="referral-notice" aria-labelledby="referral-notice-heading">
-        <h2 id="referral-notice-heading">
+    <section class="referral-notice" aria-labelledby="referral-notice-heading">
+      <h2 id="referral-notice-heading">
+        <% if @petition.completed? %>
+          <%= t(:"ui.petitions.referral_threshold.completed.heading") %>
+        <% else %>
           <%= t(:"ui.petitions.referral_threshold.closed.heading") %>
-        </h2>
-
-        <% if @petition.scot_parl_link? %>
-          <p><%= t(:"ui.petitions.referral_threshold.closed.link_html", link: @petition.scot_parl_link) %></p>
         <% end %>
-      </section>
-    <% end %>
+      </h2>
+
+      <% if @petition.scot_parl_link? %>
+        <% if @petition.completed? %>
+          <p class="secondary"><%= t(:"ui.petitions.referral_threshold.completed.link_html", link: @petition.scot_parl_link) %></p>
+        <% else %>
+          <p class="secondary"><%= t(:"ui.petitions.referral_threshold.closed.link_html", link: @petition.scot_parl_link) %></p>
+        <% end %>
+      <% end %>
+    </section>
 
     <div class="signature-count">
       <% if petition.collect_signatures? %>

--- a/config/locales/ui.en-GB.yml
+++ b/config/locales/ui.en-GB.yml
@@ -653,7 +653,7 @@ en-GB:
           link_html: |-
             <a href="%{link}">Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition</a>
         closed:
-          heading: "This petition is now under consideration by the Citizen Participation and Public Petitions Committee"
+          heading: "This petition was considered by the Scottish Parliament"
           link_html: |-
             <a href="%{link}">Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition</a>
         referred:

--- a/config/locales/ui.gd-GB.yml
+++ b/config/locales/ui.gd-GB.yml
@@ -654,7 +654,7 @@ gd-GB:
           link_html: |-
             <a href="%{link}">Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition</a>
         closed:
-          heading: "This petition is now under consideration by the Citizen Participation and Public Petitions Committee"
+          heading: "This petition was considered by the Scottish Parliament"
           link_html: |-
             <a href="%{link}">Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition</a>
         referred:

--- a/spec/presenters/petition_csv_presenter_spec.rb
+++ b/spec/presenters/petition_csv_presenter_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe PetitionCSVPresenter do
 
       [
         [:closed_at, :completed_at, ->(petition) { timestampify(petition.completed_at) }],
-        [:under_consideration_at, :closed_at, ->(petition) { timestampify(petition.closed_at) }],
+        [:under_consideration_at, :open_at, ->(petition) { timestampify(petition.open_at) }],
         [:summary, :background],
         [:background_information, :additional_details],
         [:title, :action]
@@ -87,7 +87,7 @@ RSpec.describe PetitionCSVPresenter do
       timestampify(petition.created_at),
       timestampify(petition.updated_at),
       timestampify(petition.open_at),
-      timestampify(petition.closed_at),
+      timestampify(petition.open_at),
       timestampify(petition.completed_at),
       datestampify(petition.scheduled_debate_date),
       timestampify(petition.referral_threshold_reached_at),
@@ -123,7 +123,7 @@ RSpec.describe PetitionCSVPresenter do
       timestampify(petition.created_at),
       timestampify(petition.updated_at),
       timestampify(petition.open_at),
-      timestampify(petition.closed_at),
+      timestampify(petition.open_at),
       timestampify(petition.completed_at),
       datestampify(petition.scheduled_debate_date),
       timestampify(petition.referral_threshold_reached_at),


### PR DESCRIPTION
- Check for closing date before comparing closing date when publishing a petition
- Use open_at date for under_consideration_at in petition CSV downloads
- Fix notification boxes' wording on the closed petition show page