### PR TITLE
Unset closed_at date on open petitions

### DIFF
--- a/db/migrate/20230103152832_reassign_collecting_signature_petitions_to_under_consideration.rb
+++ b/db/migrate/20230103152832_reassign_collecting_signature_petitions_to_under_consideration.rb
@@ -11,7 +11,7 @@ class ReassignCollectingSignaturePetitionsToUnderConsideration < ActiveRecord::M
       execute <<~SQL
         UPDATE petitions
         SET collect_signatures = true
-        WHERE state IN ('pending', 'validated', 'sponsored', 'flagged', 'opened')
+        WHERE state IN ('pending', 'validated', 'sponsored', 'flagged', 'open')
         AND collect_signatures = false;
       SQL
     end

--- a/db/migrate/20230130124656_unset_closed_at_date_on_open_petitions.rb
+++ b/db/migrate/20230130124656_unset_closed_at_date_on_open_petitions.rb
@@ -1,0 +1,17 @@
+class UnsetClosedAtDateOnOpenPetitions < ActiveRecord::Migration[6.1]
+  def change
+    up_only do 
+      execute <<~SQL
+        UPDATE petitions
+        SET closed_at = NULL
+        WHERE state IN ('pending', 'validated', 'sponsored', 'flagged', 'open', 'closed')
+      SQL
+
+      execute <<~SQL
+        UPDATE petitions
+        SET state = 'open'
+        WHERE state = 'closed'
+      SQL
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_03_152832) do
+ActiveRecord::Schema.define(version: 2023_01_30_124656) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "intarray"


### PR DESCRIPTION
Petitions in the previous version of the site would have their closed_at dates set when opened, and so in the new version would appear closed.

This unsets that so their state remains open