### PR TITLE
Use open at date for referred for continuity

### DIFF
--- a/app/views/petitions/_open_petition_show.html.erb
+++ b/app/views/petitions/_open_petition_show.html.erb
@@ -11,7 +11,7 @@
         <span class="label"><%= t(:"ui.petitions.created_by") %></span> <%= petition.creator.name %>
       </li>
       <li class="meta-referred-at">
-        <span class="label"><%= t(:"ui.petitions.date_referred") %></span> <%= short_date_format petition.referred_at %>
+        <span class="label"><%= t(:"ui.petitions.date_referred") %></span> <%= short_date_format petition.open_at %>
       </li>
       <li class="meta-deadline">
         <%= t(:"ui.petitions.petitions_run_length") %>


### PR DESCRIPTION
Use the open_at date for when petitions were referred as this will keep the date consistent with the previous way it was showed, causing less confusion for petitioners