### PR TITLE
Initialise the character counter when the page content is ready

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,4 +32,8 @@ RUN mkdir -p "/root/.config/chromium/Crash Reports/pending/"
 
 WORKDIR /app
 
+COPY ./docker-entrypoint.sh /docker-entrypoint.sh
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+
 CMD ["/bin/bash"]

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -2,3 +2,4 @@
 //= require frontend/character-counter
 //= require frontend/details
 //= require frontend/auto-updater
+//= require frontend/onready

--- a/app/assets/javascripts/frontend/onready.js
+++ b/app/assets/javascripts/frontend/onready.js
@@ -1,0 +1,3 @@
+document.addEventListener('DOMContentLoaded', function(event) {
+  GOVUK.PETS.characterCounter();
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,7 +3,6 @@ version: "3.7"
 x-application: &application
   image: scottish-petitions/ruby
   build: .
-  entrypoint: ./docker-entrypoint.sh
   environment:
   volumes:
     - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,23 +57,15 @@ services:
     <<: *application
     environment:
       <<: *environment
-    command: [
-      "bin/delayed_job", "start",
-      "-p", "worker",
-      "--min-priority", "10",
-      "--daemon_options", "-t"
-    ]
+      MIN_PRIORITY: "10"
+    command: [ "rake", "jobs:work" ]
 
   counter:
     <<: *application
     environment:
       <<: *environment
-    command: [
-      "bin/delayed_job", "start",
-      "-p", "counter",
-      "--max-priority", "5",
-      "--daemon_options", "-t"
-    ]
+      MAX_PRIORITY: "5"
+    command: [ "rake", "jobs:work" ]
 
 volumes:
   bundle:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -16,5 +16,5 @@ else
   yarn install
   bundle check || bundle install
 
-  bundle exec "$@"
+  exec bundle exec "$@"
 fi


### PR DESCRIPTION
This was broken when changing over to the jasmine-selenium-runner for specs.
