### PR TITLE
Upgrade net-http-persistent gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     chronic (0.10.2)
     coderay (1.1.2)
     concurrent-ruby (1.3.1)
-    connection_pool (2.2.1)
+    connection_pool (2.4.1)
     crack (0.4.5)
       rexml
     crass (1.0.6)
@@ -245,7 +245,7 @@ GEM
     multi_test (0.1.2)
     multipart-post (2.0.0)
     nenv (0.3.0)
-    net-http-persistent (3.0.0)
+    net-http-persistent (4.0.2)
       connection_pool (~> 2.2)
     net-imap (0.4.12)
       date


### PR DESCRIPTION
The current version doesn't support Ruby 3.0 and we need to deploy it before rolling the servers to the upgraded versions.