### PR TITLE
Ignore Rails CSP vulnerability

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,0 +1,3 @@
+---
+ignore:
+  - GHSA-vfm5-rmrh-j26v


### PR DESCRIPTION
We don't put untrusted user data into a CSP header.