### PR TITLE
Update content for new committee name

### DIFF
--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,3 +1,2 @@
 ---
-ignore:
-  - GHSA-vfm5-rmrh-j26v
+ignore: []

--- a/.bundler-audit.yml
+++ b/.bundler-audit.yml
@@ -1,2 +1,3 @@
 ---
-ignore: []
+ignore:
+  - GHSA-h4w6-wx8r-p68v

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -297,7 +297,10 @@ GEM
       racc (~> 1.4)
     nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    pg (1.4.6)
+    pg (1.6.3-aarch64-linux)
+    pg (1.6.3-arm64-darwin)
+    pg (1.6.3-x86_64-darwin)
+    pg (1.6.3-x86_64-linux)
     pp (0.6.4)
       prettyprint
     prettyprint (0.2.0)
@@ -640,7 +643,10 @@ CHECKSUMS
   nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
   nokogiri (1.19.4-x86_64-darwin) sha256=7fd17057d3e1f00e9954a74b3cd76595d3d4a5ef233b7ed9599047c204f70551
   nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
-  pg (1.4.6) sha256=d98f3dcb4a6ae29780a2219340cb0e55dbafbb7eb4ccc2b99f892f2569a7a61e
+  pg (1.6.3-aarch64-linux) sha256=0698ad563e02383c27510b76bf7d4cd2de19cd1d16a5013f375dd473e4be72ea
+  pg (1.6.3-arm64-darwin) sha256=7240330b572e6355d7c75a7de535edb5dfcbd6295d9c7777df4d9dddfb8c0e5f
+  pg (1.6.3-x86_64-darwin) sha256=ee2e04a17c0627225054ffeb43e31a95be9d7e93abda2737ea3ce4a62f2729d6
+  pg (1.6.3-x86_64-linux) sha256=5d9e188c8f7a0295d162b7b88a768d8452a899977d44f3274d1946d67920ae8d
   pp (0.6.4) sha256=dfcb0fce700c41456265922884f9fe195d7fbb0674a3578e6c0f69588e82b570
   prettyprint (0.2.0) sha256=2bc9e15581a94742064a3cc8b0fb9d45aae3d03a1baa6ef80922627a0766f193
   prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85

--- a/app/assets/stylesheets/petitions/admin/views/_shared.scss
+++ b/app/assets/stylesheets/petitions/admin/views/_shared.scss
@@ -103,7 +103,7 @@
   .button_to {
     display: inline-block;
 
-    input[type=submit], a {
+    input[type=submit], a, button {
       margin: 0;
       font-size: 12px;
       padding: 2px 8px;

--- a/config/locales/ui.en-GB.yml
+++ b/config/locales/ui.en-GB.yml
@@ -11,7 +11,7 @@ en-GB:
         <h1 id="page-heading">A new petitions site is coming on 6 April</h1>
         <p>Sorry, the petitions service is currently unavailable. We are launching a new, improved website for petitions on 6 April.</p>
         <p>Please accept our apologies for any inconvenience.</p>
-        <p>Click here to find out more about the work of the <a href="https://www.parliament.scot/chamber-and-committees/committees/current-and-previous-committees/session-6-citizen-participation-and-public-petitions-committee">Citizen Participation and Public Petitions Committee</a>.</p>
+        <p>Click here to find out more about the work of the <a href="https://www.parliament.scot/chamber-and-committees/committees/current-and-previous-committees/session-6-citizen-participation-and-public-petitions-committee">Public Petitions Committee</a>.</p>
     cc:
       statement:
         name: "Find out more about the cookies on this website"
@@ -50,13 +50,13 @@ en-GB:
           <span class="count">%{num}</span> petitions are currently collecting signatures
       referred_html:
         one: |-
-          <span class="count">1</span> petition was referred to the Citizen Participation and Public Petitions Committee
+          <span class="count">1</span> petition was referred to the Public Petitions Committee
         two: |-
-          <span class="count">2</span> petitions were referred to the Citizen Participation and Public Petitions Committee
+          <span class="count">2</span> petitions were referred to the Public Petitions Committee
         zero: |-
-          <span class="count">0</span> petitions were referred to the Citizen Participation and Public Petitions Committee
+          <span class="count">0</span> petitions were referred to the Public Petitions Committee
         other: |-
-          <span class="count">%{num}</span> petitions were referred to the Citizen Participation and Public Petitions Committee
+          <span class="count">%{num}</span> petitions were referred to the Public Petitions Committee
       debated_explanation_html: |-
         See all petitions debated by Parliament (%{num})
       referred_explanation_html: |-
@@ -189,23 +189,23 @@ en-GB:
           <li>Lead to, or influence, a debate in the Chamber.</li>
         </ul>
 
-        <p>All petitions should be made using our online petitions system. If you cannot use the system, please get in touch with the <a href="/contact">Citizen Participation and Public Petitions team</a>.</p>
+        <p>All petitions should be made using our online petitions system. If you cannot use the system, please get in touch with the <a href="/contact">Public Petitions team</a>.</p>
 
         <section aria-labelledby="how-petitions-work-heading">
           <h2 id="how-petitions-work-heading"><a name="how-petitions-work"></a>How petitions work</h2>
 
           <ol class="list-number">
             <li>Any person or organisation can submit a petition. You do not have to be a certain age or live in Scotland (but your petition must be about something that is <a href="https://www.parliament.scot/about/how-parliament-works/powers-of-the-scottish-parliament">“devolved”</a> within the Scottish Parliament’s powers).</li>
-            <li>Your petition can collect signatures until your petition is closed by the Citizen Participation and Public Petitions Committee. This will start once your petition has been published by the CPPPC team.</li>
-            <li>Once we have received your petition, the CPPPC team will check to make sure it meets the <a href="/rules">Parliament’s rules</a> and is clear. Petitions that don’t meet these rules will be rejected.</li>
+            <li>Your petition can collect signatures until your petition is closed by the Public Petitions Committee. This will start once your petition has been published by the team.</li>
+            <li>Once we have received your petition, the team will check to make sure it meets the <a href="/rules">Parliament’s rules</a> and is clear. Petitions that don’t meet these rules will be rejected.</li>
             <li>People can only sign a petition once. If they sign the petition online, they will be sent an email to verify their signature.</li>
           </ol>
         </section>
 
         <section aria-labelledby="the-petitions-committee-heading">
-          <h2 id="the-petitions-committee-heading"><a name="the-petitions-committee"></a>The Citizen Participation and Public Petitions Committee</h2>
+          <h2 id="the-petitions-committee-heading"><a name="the-petitions-committee"></a>The Public Petitions Committee</h2>
 
-          <p>The <a href="/contact">Citizen Participation and Public Petitions Committee</a> looks at all published petitions, regardless of the number of signatures they collect. The Committee will decide what action it wants to take. This can include:</p>
+          <p>The <a href="/contact">Public Petitions Committee</a> looks at all published petitions, regardless of the number of signatures they collect. The Committee will decide what action it wants to take. This can include:</p>
 
           <ul class="list-bullet">
             <li>asking for evidence from the Scottish Government, other organisations, or people</li>
@@ -237,7 +237,7 @@ en-GB:
         <section aria-labelledby="rejections-heading">
           <h2 id="rejections-heading"><a name="rejections"></a>Why we might reject your petition</h2>
 
-          <p>The Citizen Participation and Public Petitions team reject petitions that do not meet the <a href="/rules">rules</a>. If we reject your petition, we will tell you why. If we can, we will suggest other ways you could raise your issue.</p>
+          <p>The Public Petitions team reject petitions that do not meet the <a href="/rules">rules</a>. If we reject your petition, we will tell you why. If we can, we will suggest other ways you could raise your issue.</p>
 
           <p>We'll have to reject your petition if:</p>
 
@@ -261,7 +261,7 @@ en-GB:
 
           <ul class="list-bullet">
             <li>the <a href="/rules#standing-orders">Standing Orders</a> of the Scottish Parliament (the rules for how the Parliament works)</li>
-            <li>a <a href="/rules#determination">determination</a> agreed by the Citizen Participation and Public Petitions Committee</li>
+            <li>a <a href="/rules#determination">determination</a> agreed by the Citizen Participation and Public Petitions Committee in January 2026</li>
           </ul>
 
           <p>If you have any other questions, please %{contact_link}.</p>
@@ -271,19 +271,17 @@ en-GB:
     contact_page:
       body_html: |-
         <h1 id="page-heading">Contact</h1>
-        <p>If you have any questions, the CPPPC team are available to help.</p>
-        <p>Due to the Covid-19 public health emergency, the team are working from home and therefore response times will be affected.</p>
+        <p>If you have any questions, the Public Petitions team are available to help.</p>
         <p>Before you get in touch, you might want to check if your question can be answered by our <a href="/help">‘How petitions work’</a> page.</p>
 
         <section aria-labelled="email-heading">
           <h2 id="email-heading"><a name="email"></a>Email</h2>
-          <p>The quickest way to contact the CPPPC team is by email at <a href="mailto:petitions.committee@parliament.scot">petitions.committee@parliament.scot</a>.</p>
+          <p>The quickest way to contact the team is by email at <a href="mailto:petitions.committee@parliament.scot">petitions.committee@parliament.scot</a>.</p>
         </section>
 
         <section aria-labelled="phone-heading">
           <h2 id="phone-heading"><a name="phone"></a>Phone</h2>
           <p>If you are unable to contact us by email, you can phone us.</p>
-          <p>Phone calls are handled by the CPPPC team who are all currently working from home.</p>
           <p>If you leave us a message and a contact number, one of the team will get back to you as soon as possible.</p>
           <p>Please note the voicemail service is only checked intermittently.</p>
           <p>Telephone: <a href="tel:01313485254">0131 348 5254</a></p>
@@ -309,7 +307,7 @@ en-GB:
         debate: |-
           If a petition gets %{formatted_count} signatures, it will be considered for a debate in Parliament
         referred: |-
-          All petitions with more than %{formatted_count} signatures are discussed by the Citizen Participation and Public Petitions Committee
+          All petitions with more than %{formatted_count} signatures are discussed by the Public Petitions Committee
       local_petitions:
         heading: "Local to you"
         find_local_petitions: "Find petitions being signed by people near you"
@@ -337,7 +335,7 @@ en-GB:
       referred_petitions:
         title: "Petitions under consideration"
         introduction: |-
-          The Citizen Participation and Public Petitions Committee looks at all published petitions.
+          The Public Petitions Committee looks at all published petitions.
         none_referred: |-
           No petitions are being considered yet
         referred_date: "Under consideration from %{date}"
@@ -378,7 +376,7 @@ en-GB:
           open: "Open petitions"
           closed: "Closed petitions"
           debated: "Petitions debated by Parliament"
-          referred: "Petitions referred to the Citizen Participation and Public Petitions Committee"
+          referred: "Petitions referred to the Public Petitions Committee"
           rejected: "Rejected petitions"
           completed: "Completed petitions"
           published: "Published petitions"
@@ -488,8 +486,8 @@ en-GB:
           intro_html: |-
             <h1 id="page-heading">Start a petition</h1>
             <p>Remember, your petition must meet the <a href="/rules">rules for petitions</a>.
-              Your petition can collect signatures until your petition is closed by the Citizen
-              Participation and Public Petitions Committee.
+              Your petition can collect signatures until your petition is closed by the
+              Public Petitions Committee.
             </p>
           submit_html: |-
             <button type="submit" name="move_next" class="button forward" data-disable-with="Preview petition">Preview petition</button>
@@ -551,7 +549,7 @@ en-GB:
         confirmation_link_emailed: "We’ve emailed you a link to confirm your email address"
         confirmation_needed: "Please click the link in the email we have sent you to confirm your email address"
         n_sponsors_needed: |-
-          %{count} people need to click this link and confirm their support for your petition to go live. Once this has happened the CPPPC team will check that it meets the petitions standards and arrange for it to be translated. You will receive an email when it is published.
+          %{count} people need to click this link and confirm their support for your petition to go live. Once this has happened the Public Petitions team will check that it meets the petitions standards and arrange for it to be translated. You will receive an email when it is published.
         n_sponsors_needed_notice: |-
           Your petition will only go live after %{count} people confirm their support
         n_sponsors_needed_heading: |-
@@ -614,7 +612,7 @@ en-GB:
         min_supporters_reached: |
           %{min_supporters} people have already supported %{creator_name}’s petition.
         checking_standards_html: |-
-          The CPPPC team need to check your petition meets the Parliament's rules and is clear.
+          The Public Petitions team need to check your petition meets the Parliament's rules and is clear.
       notice_rejected: "This petition was rejected"
       heading_rejected: "Rejected petition"
       topic_debated_on: "This topic was debated on %{date}"
@@ -632,7 +630,7 @@ en-GB:
           <details>
             <summary><span>Help writing the background information</span></summary>
             <div>
-              <p>This section is for you to give more information to the Citizen Participation and Public Petitions Committee about your petition. Use this section to help the committee understand in more detail the issues your petition raises.</p>
+              <p>This section is for you to give more information to the Public Petitions Committee about your petition. Use this section to help the committee understand in more detail the issues your petition raises.</p>
               <p>You can add links to webpages you think might be helpful. Please do not link to webpages with commenting sections (like news articles which we cannot publish).</p>
               <p>We cannot accept additional petition information like:</p>
               <ul class="list-bullet">
@@ -652,16 +650,16 @@ en-GB:
         waiting:
           heading: "This petition is now under consideration"
           link_html: |-
-            <a href="%{link}">Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition</a>
+            <a href="%{link}">Find out about the Public Petitions Committee’s discussion of this petition</a>
         closed:
           heading: "This petition was considered by the Scottish Parliament"
           link_html: |-
-            <a href="%{link}">Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition</a>
+            <a href="%{link}">Find out about the Public Petitions Committee’s discussion of this petition</a>
         referred:
           heading: |-
             This petition is now under consideration
           link_html: |-
-            <a href="%{link}">Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition</a>
+            <a href="%{link}">Find out about the Public Petitions Committee’s discussion of this petition</a>
         completed:
           heading: |-
             This petition was considered by the Scottish Parliament
@@ -670,7 +668,7 @@ en-GB:
         needs_more_signatures:
           heading: "At %{threshold} signatures…"
           referral_threshold: |-
-            All petitions with more than %{threshold} signatures will be discussed by the Citizen Participation and Public Petitions Committee
+            All petitions with more than %{threshold} signatures will be discussed by the Public Petitions Committee
       parliament_will_debate: |-
         Parliament will debate this petition
       sign_this_petition: |-
@@ -684,7 +682,7 @@ en-GB:
       reject_reason_heading: |-
         Why was this petition rejected?
       parliament_debate_heading: |-
-        The Citizen Participation and Public Petitions Committee will consider this for a debate
+        The Public Petitions Committee will consider this for a debate
       parliament_will_debate_on: |-
         Parliament will debate this petition on %{date}.
       closed_due_to_election: |-
@@ -705,7 +703,7 @@ en-GB:
           </p>
         </details>
       parliament_debate_description: |-
-        The Citizen Participation and Public Petitions Committee considers all petitions that get more than %{threshold} signatures for a debate
+        The Public Petitions Committee considers all petitions that get more than %{threshold} signatures for a debate
       need_sponsors_later_heading: |-
         Just so you know
       watch_online_parliament_tv_html: |-
@@ -716,7 +714,7 @@ en-GB:
         <p>We only reject petitions that don’t meet the %{standards_link}</p>
         <p>Rejected petitions are published in the language in which they were submitted</p>
       committee_decided_not_to_debate: |-
-        The Citizen Participation and Public Petitions Committee decided not to refer this petition for a debate
+        The Public Petitions Committee decided not to refer this petition for a debate
       at_threshold_for_debate_ellipsis: |-
         At %{threshold} signatures…
       watch_online_youtube_channel_html: |-
@@ -818,19 +816,19 @@ en-GB:
       share_this_petition: |-
         Share this petition
       twitter_card_description: |-
-        Official online petitions in response to issues of the day, listing the number that were referred to the Citizen Participation and Public Petitions Committee, and those that have been debated by the Scottish Parliament
+        Official online petitions in response to issues of the day, listing the number that were referred to the Public Petitions Committee, and those that have been debated by the Scottish Parliament
     share_title: "Petition: %{petition}"
     list_headers:
       open_html: |-
         <p class="text-secondary">These petitions are collecting signatures</p>
       referred_html: |-
-        <p class="text-secondary">These petitions are currently being considered by the Citizen Participation and Public Petitions Committee</p>
+        <p class="text-secondary">These petitions are currently being considered by the Public Petitions Committee</p>
       debated_html: |-
         <p class="text-secondary">These petitions were debated by Parliament in Plenary</p>
       not_debated_html: |-
-        <p class="text-secondary">The Citizen Participation and Public Petitions Committee decided not to request a Plenary debate on these petitions</p>
+        <p class="text-secondary">The Public Petitions Committee decided not to request a Plenary debate on these petitions</p>
       completed_html: |-
-        <p class="text-secondary">The Citizen Participation and Public Petitions Committee has finished considering these petitions</p>
+        <p class="text-secondary">The Public Petitions Committee has finished considering these petitions</p>
       rejected_html: |-
         <p class="text-secondary">These petitions did not meet the <a href="/help#rules">rules for petitions</a>. They are published in the language in which they were submitted.</p>
     local_search:
@@ -859,7 +857,7 @@ en-GB:
             <li>Contact you about petitions you start</li>
             <li>We may occasionally contact people who start or submit petitions to seek feedback on the petitions process and how it could be improved</li>
             <li>We will use your personal information to process the petition you have started or signed</li>
-            <li>If you start a petition and we accept it, your name will be published alongside any text you include within the petition. We will not publish any of your contact details. If you start a petition, your name will remain permanently referenced alongside the petition on the Citizen Participation and Public Petitions Committee’s web pages and in meeting transcripts and recordings, as part of the Official Report of the Scottish Parliament’s petitions process. This information will be transferred to the National Records of Scotland (NRS) where it will be publicly available</li>
+            <li>If you start a petition and we accept it, your name will be published alongside any text you include within the petition. We will not publish any of your contact details. If you start a petition, your name will remain permanently referenced alongside the petition on the Public Petitions Committee’s web pages and in meeting transcripts and recordings, as part of the Official Report of the Scottish Parliament’s petitions process. This information will be transferred to the National Records of Scotland (NRS) where it will be publicly available</li>
             <li>Your petition, including your name, will be included in data about parliamentary business that will be available on the Parliament’s Open Data Portal on an ongoing basis. The Open Data Portal can be accessed here: <a href="https://data.parliament.scot/#/home">https://data.parliament.scot/#/home</a></li>
             <li>If you’ve signed a petition, we will not publish any personal information about you</li>
             <li>IP addresses are used to protect the petitions site and prevent fraudulent activity.</li>
@@ -890,7 +888,7 @@ en-GB:
 
           <p>We sometimes receive information relating to people who have submitted petitions in writing. Some may contain special category personal data. These petitions are securely stored and retained for the same period as personal data received through our own electronic petitions system.</p>
 
-          <p>If a petition you’ve started is referred to the Citizen Participation and Public Petitions Committee, we will use your contact details to update you about the petition’s progress and to offer you the opportunity to provide further information and engage with the Committee.</p>
+          <p>If a petition you’ve started is referred to the Public Petitions Committee, we will use your contact details to update you about the petition’s progress and to offer you the opportunity to provide further information and engage with the Committee.</p>
 
           <p>You will receive automated confirmation emails when you set up or sign a petition.</p>
 
@@ -1137,7 +1135,7 @@ en-GB:
 
         <ul class="list-bullet">
           <li>the Standing Orders of the Scottish Parliament (the rules for how the Parliament works)</li>
-          <li>a “determination” (rules) agreed by the Citizen Participation and Public Petitions Committee</li>
+          <li>a “determination” (rules) agreed by the Citizen Participation and Public Petitions Committee in January 2026</li>
         </ul>
 
         <section aria-labelledby="standing-orders-heading">
@@ -1171,7 +1169,7 @@ en-GB:
         <section aria-labelledby="determination-heading">
           <h2 id="determination-heading"><a name="determination"></a>Determination on proper form of petitions</h2>
 
-          <p>To be read alongside the Parliament’s rules on public petitions, the Citizen Participation and Public Petitions Committee has made the following determination under Rule 15.4.3 on proper form of petitions.</p>
+          <p>Under rule 15.4.3 of Standing Orders, the Public Petition Committee is required to publish a determination on the proper form for petitions. The following determination was agreed in January 2026.</p>
 
           <ul class="list-bullet">
             <li>
@@ -1200,7 +1198,7 @@ en-GB:
               <p>We ask that you take previous action to address the issue you are concerned about because the response you receive could help you decide whether further action is needed on the issue you have raised and how you want to proceed. This may be by submitting a petition or the response from the Scottish Government or your MSP might identify a different route that you feel would be a better way of achieving your aim. Please allow a reasonable amount of time (roughly 4 weeks) for a response.</p>
             </li>
             <li>
-              <p>A petition will not be considered by the Citizen Participation and Public Petitions Committee if the same (or substantially similar) petition, submitted by the same petitioner, has previously been considered by the Committee and closed at its first consideration on three consecutive occasions.</p>
+              <p>A petition will not be considered by the Public Petitions Committee if the same (or substantially similar) petition, submitted by the same petitioner, has previously been considered by the Committee and closed at its first consideration on three consecutive occasions.</p>
             </li>
             <li>
               <p>Petitions should not:</p>

--- a/config/locales/ui.gd-GB.yml
+++ b/config/locales/ui.gd-GB.yml
@@ -11,7 +11,7 @@ gd-GB:
         <h1 id="page-heading">A new petitions site is coming on 6 April</h1>
         <p>Sorry, the petitions service is currently unavailable. We are launching a new, improved website for petitions on 6 April.</p>
         <p>Please accept our apologies for any inconvenience.</p>
-        <p>Click here to find out more about the work of the <a href="https://www.parliament.scot/chamber-and-committees/committees/current-and-previous-committees/session-6-citizen-participation-and-public-petitions-committee">Citizen Participation and Public Petitions Committee</a>.</p>
+        <p>Click here to find out more about the work of the <a href="https://www.parliament.scot/chamber-and-committees/committees/current-and-previous-committees/session-6-citizen-participation-and-public-petitions-committee">Public Petitions Committee</a>.</p>
     cc:
       statement:
         name: "Find out more about the cookies on this website"
@@ -50,13 +50,13 @@ gd-GB:
           <span class="count">%{num}</span> petitions are currently collecting signatures
       referred_html:
         one: |-
-          <span class="count">1</span> petition was referred to the Citizen Participation and Public Petitions Committee
+          <span class="count">1</span> petition was referred to the Public Petitions Committee
         two: |-
-          <span class="count">2</span> petitions were referred to the Citizen Participation and Public Petitions Committee
+          <span class="count">2</span> petitions were referred to the Public Petitions Committee
         zero: |-
-          <span class="count">0</span> petitions were referred to the Citizen Participation and Public Petitions Committee
+          <span class="count">0</span> petitions were referred to the Public Petitions Committee
         other: |-
-          <span class="count">%{num}</span> petitions were referred to the Citizen Participation and Public Petitions Committee
+          <span class="count">%{num}</span> petitions were referred to the Public Petitions Committee
       debated_explanation_html: |-
         See all petitions debated by Parliament (%{num})
       referred_explanation_html: |-
@@ -189,23 +189,23 @@ gd-GB:
           <li>Lead to, or influence, a debate in the Chamber.</li>
         </ul>
 
-        <p>All petitions should be made using our online petitions system. If you cannot use the system, please get in touch with the <a href="/contact">Citizen Participation and Public Petitions team</a>.</p>
+        <p>All petitions should be made using our online petitions system. If you cannot use the system, please get in touch with the <a href="/contact">Public Petitions team</a>.</p>
 
         <section aria-labelledby="how-petitions-work-heading">
           <h2 id="how-petitions-work-heading"><a name="how-petitions-work"></a>How petitions work</h2>
 
           <ol class="list-number">
             <li>Any person or organisation can submit a petition. You do not have to be a certain age or live in Scotland (but your petition must be about something that is <a href="https://www.parliament.scot/about/how-parliament-works/powers-of-the-scottish-parliament">“devolved”</a> within the Scottish Parliament’s powers).</li>
-            <li>Your petition can collect signatures until your petition is closed by the Citizen Participation and Public Petitions Committee. This will start once your petition has been published by the CPPPC team.</li>
-            <li>Once we have received your petition, the CPPPC team will check to make sure it meets the <a href="/rules">Parliament’s rules</a> and is clear. Petitions that don’t meet these rules will be rejected.</li>
+            <li>Your petition can collect signatures until your petition is closed by the Public Petitions Committee. This will start once your petition has been published by the team.</li>
+            <li>Once we have received your petition, the team will check to make sure it meets the <a href="/rules">Parliament’s rules</a> and is clear. Petitions that don’t meet these rules will be rejected.</li>
             <li>People can only sign a petition once. If they sign the petition online, they will be sent an email to verify their signature.</li>
           </ol>
         </section>
 
         <section aria-labelledby="the-petitions-committee-heading">
-          <h2 id="the-petitions-committee-heading"><a name="the-petitions-committee"></a>The Citizen Participation and Public Petitions Committee</h2>
+          <h2 id="the-petitions-committee-heading"><a name="the-petitions-committee"></a>The Public Petitions Committee</h2>
 
-          <p>The <a href="/contact">Citizen Participation and Public Petitions Committee</a> looks at all published petitions, regardless of the number of signatures they collect. The Committee will decide what action it wants to take. This can include:</p>
+          <p>The <a href="/contact">Public Petitions Committee</a> looks at all published petitions, regardless of the number of signatures they collect. The Committee will decide what action it wants to take. This can include:</p>
 
           <ul class="list-bullet">
             <li>asking for evidence from the Scottish Government, other organisations, or people</li>
@@ -237,7 +237,7 @@ gd-GB:
         <section aria-labelledby="rejections-heading">
           <h2 id="rejections-heading"><a name="rejections"></a>Why we might reject your petition</h2>
 
-          <p>The Citizen Participation and Public Petitions team reject petitions that do not meet the <a href="/rules">rules</a>. If we reject your petition, we will tell you why. If we can, we will suggest other ways you could raise your issue.</p>
+          <p>The Public Petitions team reject petitions that do not meet the <a href="/rules">rules</a>. If we reject your petition, we will tell you why. If we can, we will suggest other ways you could raise your issue.</p>
 
           <p>We'll have to reject your petition if:</p>
 
@@ -261,7 +261,7 @@ gd-GB:
 
           <ul class="list-bullet">
             <li>the <a href="/rules#standing-orders">Standing Orders</a> of the Scottish Parliament (the rules for how the Parliament works)</li>
-            <li>a <a href="/rules#determination">determination</a> agreed by the Citizen Participation and Public Petitions Committee</li>
+            <li>a <a href="/rules#determination">determination</a> agreed by the Citizen Participation and Public Petitions Committee in January 2026</li>
           </ul>
 
           <p>If you have any other questions, please %{contact_link}.</p>
@@ -271,19 +271,17 @@ gd-GB:
     contact_page:
       body_html: |-
         <h1 id="page-heading">Contact</h1>
-        <p>If you have any questions, the CPPPC team are available to help.</p>
-        <p>Due to the Covid-19 public health emergency, the team are working from home and therefore response times will be affected.</p>
+        <p>If you have any questions, the Public Petitions team are available to help.</p>
         <p>Before you get in touch, you might want to check if your question can be answered by our <a href="/help">‘How petitions work’</a> page.</p>
 
         <section aria-labelled="email-heading">
           <h2 id="email-heading"><a name="email"></a>Email</h2>
-          <p>The quickest way to contact the CPPPC team is by email at <a href="mailto:petitions.committee@parliament.scot">petitions.committee@parliament.scot</a>.</p>
+          <p>The quickest way to contact the team is by email at <a href="mailto:petitions.committee@parliament.scot">petitions.committee@parliament.scot</a>.</p>
         </section>
 
         <section aria-labelled="phone-heading">
           <h2 id="phone-heading"><a name="phone"></a>Phone</h2>
           <p>If you are unable to contact us by email, you can phone us.</p>
-          <p>Phone calls are handled by the CPPPC team who are all currently working from home.</p>
           <p>If you leave us a message and a contact number, one of the team will get back to you as soon as possible.</p>
           <p>Please note the voicemail service is only checked intermittently.</p>
           <p>Telephone: <a href="tel:01313485254">0131 348 5254</a></p>
@@ -309,7 +307,7 @@ gd-GB:
         debate: |-
           If a petition gets %{formatted_count} signatures, it will be considered for a debate in Parliament
         referred: |-
-          All petitions with more than %{formatted_count} signatures are discussed by the Citizen Participation and Public Petitions Committee
+          All petitions with more than %{formatted_count} signatures are discussed by the Public Petitions Committee
       local_petitions:
         heading: "Local to you"
         find_local_petitions: "Find petitions being signed by people near you"
@@ -337,7 +335,7 @@ gd-GB:
       referred_petitions:
         title: "Petitions under consideration"
         introduction: |-
-          The Citizen Participation and Public Petitions Committee looks at all published petitions.
+          The Public Petitions Committee looks at all published petitions.
         none_referred: |-
           No petitions are being considered yet
         referred_date: "Under consideration from %{date}"
@@ -378,7 +376,7 @@ gd-GB:
           open: "Open petitions"
           closed: "Closed petitions"
           debated: "Petitions debated by Parliament"
-          referred: "Petitions referred to the Citizen Participation and Public Petitions Committee"
+          referred: "Petitions referred to the Public Petitions Committee"
           rejected: "Rejected petitions"
           completed: "Completed petitions"
           published: "Published petitions"
@@ -488,8 +486,8 @@ gd-GB:
           intro_html: |-
             <h1 id="page-heading">Start a petition</h1>
             <p>Remember, your petition must meet the <a href="/rules">rules for petitions</a>.
-              Your petition can collect signatures until your petition is closed by the Citizen
-              Participation and Public Petitions Committee.
+              Your petition can collect signatures until your petition is closed by the
+              Public Petitions Committee.
             </p>
           submit_html: |-
             <button type="submit" name="move_next" class="button forward" data-disable-with="Preview petition">Preview petition</button>
@@ -551,7 +549,7 @@ gd-GB:
         confirmation_link_emailed: "We’ve emailed you a link to confirm your email address"
         confirmation_needed: "Please click the link in the email we have sent you to confirm your email address"
         n_sponsors_needed: |-
-          %{count} people need to click this link and confirm their support for your petition to go live. Once this has happened the CPPPC team will check that it meets the petitions standards and arrange for it to be translated. You will receive an email when it is published.
+          %{count} people need to click this link and confirm their support for your petition to go live. Once this has happened the Public Petitions team will check that it meets the petitions standards and arrange for it to be translated. You will receive an email when it is published.
         n_sponsors_needed_notice: |-
           Your petition will only go live after %{count} people confirm their support
         n_sponsors_needed_heading: |-
@@ -614,7 +612,7 @@ gd-GB:
         min_supporters_reached: |
           %{min_supporters} people have already supported %{creator_name}’s petition.
         checking_standards_html: |-
-          The CPPPC team need to check your petition meets the Parliament's rules and is clear.
+          The Public Petitions team need to check your petition meets the Parliament's rules and is clear.
       notice_rejected: "This petition was rejected"
       heading_rejected: "Rejected petition"
       topic_debated_on: "This topic was debated on %{date}"
@@ -632,7 +630,7 @@ gd-GB:
           <details>
             <summary><span>Help writing the background information</span></summary>
             <div>
-              <p>This section is for you to give more information to the Citizen Participation and Public Petitions Committee about your petition. Use this section to help the committee understand in more detail the issues your petition raises.</p>
+              <p>This section is for you to give more information to the Public Petitions Committee about your petition. Use this section to help the committee understand in more detail the issues your petition raises.</p>
               <p>You can add links to webpages you think might be helpful. Please do not link to webpages with commenting sections (like news articles which we cannot publish).</p>
               <p>We cannot accept additional petition information like:</p>
               <ul class="list-bullet">
@@ -652,16 +650,16 @@ gd-GB:
         waiting:
           heading: "This petition is now under consideration"
           link_html: |-
-            <a href="%{link}">Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition</a>
+            <a href="%{link}">Find out about the Public Petitions Committee’s discussion of this petition</a>
         closed:
           heading: "This petition was considered by the Scottish Parliament"
           link_html: |-
-            <a href="%{link}">Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition</a>
+            <a href="%{link}">Find out about the Public Petitions Committee’s discussion of this petition</a>
         referred:
           heading: |-
             This petition is now under consideration
           link_html: |-
-            <a href="%{link}">Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition</a>
+            <a href="%{link}">Find out about the Public Petitions Committee’s discussion of this petition</a>
         completed:
           heading: |-
             This petition was considered by the Scottish Parliament
@@ -670,7 +668,7 @@ gd-GB:
         needs_more_signatures:
           heading: "At %{threshold} signatures…"
           referral_threshold: |-
-            All petitions with more than %{threshold} signatures will be discussed by the Citizen Participation and Public Petitions Committee
+            All petitions with more than %{threshold} signatures will be discussed by the Public Petitions Committee
       parliament_will_debate: |-
         Parliament will debate this petition
       sign_this_petition: |-
@@ -684,7 +682,7 @@ gd-GB:
       reject_reason_heading: |-
         Why was this petition rejected?
       parliament_debate_heading: |-
-        The Citizen Participation and Public Petitions Committee will consider this for a debate
+        The Public Petitions Committee will consider this for a debate
       parliament_will_debate_on: |-
         Parliament will debate this petition on %{date}.
       closed_due_to_election: |-
@@ -705,7 +703,7 @@ gd-GB:
           </p>
         </details>
       parliament_debate_description: |-
-        The Citizen Participation and Public Petitions Committee considers all petitions that get more than %{threshold} signatures for a debate
+        The Public Petitions Committee considers all petitions that get more than %{threshold} signatures for a debate
       need_sponsors_later_heading: |-
         Just so you know
       watch_online_parliament_tv_html: |-
@@ -716,7 +714,7 @@ gd-GB:
         <p>We only reject petitions that don’t meet the %{standards_link}</p>
         <p>Rejected petitions are published in the language in which they were submitted</p>
       committee_decided_not_to_debate: |-
-        The Citizen Participation and Public Petitions Committee decided not to refer this petition for a debate
+        The Public Petitions Committee decided not to refer this petition for a debate
       at_threshold_for_debate_ellipsis: |-
         At %{threshold} signatures…
       watch_online_youtube_channel_html: |-
@@ -818,19 +816,19 @@ gd-GB:
       share_this_petition: |-
         Share this petition
       twitter_card_description: |-
-        Official online petitions in response to issues of the day, listing the number that were referred to the Citizen Participation and Public Petitions Committee, and those that have been debated by the Scottish Parliament
+        Official online petitions in response to issues of the day, listing the number that were referred to the Public Petitions Committee, and those that have been debated by the Scottish Parliament
     share_title: "Petition: %{petition}"
     list_headers:
       open_html: |-
         <p class="text-secondary">These petitions are collecting signatures</p>
       referred_html: |-
-        <p class="text-secondary">These petitions are currently being considered by the Citizen Participation and Public Petitions Committee</p>
+        <p class="text-secondary">These petitions are currently being considered by the Public Petitions Committee</p>
       debated_html: |-
         <p class="text-secondary">These petitions were debated by Parliament in Plenary</p>
       not_debated_html: |-
-        <p class="text-secondary">The Citizen Participation and Public Petitions Committee decided not to request a Plenary debate on these petitions</p>
+        <p class="text-secondary">The Public Petitions Committee decided not to request a Plenary debate on these petitions</p>
       completed_html: |-
-        <p class="text-secondary">The Citizen Participation and Public Petitions Committee has finished considering these petitions</p>
+        <p class="text-secondary">The Public Petitions Committee has finished considering these petitions</p>
       rejected_html: |-
         <p class="text-secondary">These petitions did not meet the <a href="/help#rules">rules for petitions</a>. They are published in the language in which they were submitted.</p>
     local_search:
@@ -859,7 +857,7 @@ gd-GB:
             <li>Contact you about petitions you start</li>
             <li>We may occasionally contact people who start or submit petitions to seek feedback on the petitions process and how it could be improved</li>
             <li>We will use your personal information to process the petition you have started or signed</li>
-            <li>If you start a petition and we accept it, your name will be published alongside any text you include within the petition. We will not publish any of your contact details. If you start a petition, your name will remain permanently referenced alongside the petition on the Citizen Participation and Public Petitions Committee’s web pages and in meeting transcripts and recordings, as part of the Official Report of the Scottish Parliament’s petitions process. This information will be transferred to the National Records of Scotland (NRS) where it will be publicly available</li>
+            <li>If you start a petition and we accept it, your name will be published alongside any text you include within the petition. We will not publish any of your contact details. If you start a petition, your name will remain permanently referenced alongside the petition on the Public Petitions Committee’s web pages and in meeting transcripts and recordings, as part of the Official Report of the Scottish Parliament’s petitions process. This information will be transferred to the National Records of Scotland (NRS) where it will be publicly available</li>
             <li>Your petition, including your name, will be included in data about parliamentary business that will be available on the Parliament’s Open Data Portal on an ongoing basis. The Open Data Portal can be accessed here: <a href="https://data.parliament.scot/#/home">https://data.parliament.scot/#/home</a></li>
             <li>If you’ve signed a petition, we will not publish any personal information about you</li>
             <li>IP addresses are used to protect the petitions site and prevent fraudulent activity.</li>
@@ -890,7 +888,7 @@ gd-GB:
 
           <p>We sometimes receive information relating to people who have submitted petitions in writing. Some may contain special category personal data. These petitions are securely stored and retained for the same period as personal data received through our own electronic petitions system.</p>
 
-          <p>If a petition you’ve started is referred to the Citizen Participation and Public Petitions Committee, we will use your contact details to update you about the petition’s progress and to offer you the opportunity to provide further information and engage with the Committee.</p>
+          <p>If a petition you’ve started is referred to the Public Petitions Committee, we will use your contact details to update you about the petition’s progress and to offer you the opportunity to provide further information and engage with the Committee.</p>
 
           <p>You will receive automated confirmation emails when you set up or sign a petition.</p>
 
@@ -1137,7 +1135,7 @@ gd-GB:
 
         <ul class="list-bullet">
           <li>the Standing Orders of the Scottish Parliament (the rules for how the Parliament works)</li>
-          <li>a “determination” (rules) agreed by the Citizen Participation and Public Petitions Committee</li>
+          <li>a “determination” (rules) agreed by the Citizen Participation and Public Petitions Committee in January 2026</li>
         </ul>
 
         <section aria-labelledby="standing-orders-heading">
@@ -1171,7 +1169,7 @@ gd-GB:
         <section aria-labelledby="determination-heading">
           <h2 id="determination-heading"><a name="determination"></a>Determination on proper form of petitions</h2>
 
-          <p>To be read alongside the Parliament’s rules on public petitions, the Citizen Participation and Public Petitions Committee has made the following determination under Rule 15.4.3 on proper form of petitions.</p>
+          <p>Under rule 15.4.3 of Standing Orders, the Public Petition Committee is required to publish a determination on the proper form for petitions. The following determination was agreed in January 2026.</p>
 
           <ul class="list-bullet">
             <li>
@@ -1200,7 +1198,7 @@ gd-GB:
               <p>We ask that you take previous action to address the issue you are concerned about because the response you receive could help you decide whether further action is needed on the issue you have raised and how you want to proceed. This may be by submitting a petition or the response from the Scottish Government or your MSP might identify a different route that you feel would be a better way of achieving your aim. Please allow a reasonable amount of time (roughly 4 weeks) for a response.</p>
             </li>
             <li>
-              <p>A petition will not be considered by the Citizen Participation and Public Petitions Committee if the same (or substantially similar) petition, submitted by the same petitioner, has previously been considered by the Committee and closed at its first consideration on three consecutive occasions.</p>
+              <p>A petition will not be considered by the Public Petitions Committee if the same (or substantially similar) petition, submitted by the same petitioner, has previously been considered by the Committee and closed at its first consideration on three consecutive occasions.</p>
             </li>
             <li>
               <p>Petitions should not:</p>

--- a/features/suzie_views_a_petition.feature
+++ b/features/suzie_views_a_petition.feature
@@ -122,7 +122,7 @@ Feature: Suzie views a petition
   Scenario: Suzie views a petition which will not be debated
     Given a petition "Spend more money on Defence" with a negative debate outcome
     When I view the petition
-    Then I should see "The Citizen Participation and Public Petitions Committee decided not to refer this petition for a debate"
+    Then I should see "The Public Petitions Committee decided not to refer this petition for a debate"
 
   Scenario: Suzie views a petition which was debated yesterday
     Given the date is the "27/10/2015"
@@ -173,7 +173,7 @@ Feature: Suzie views a petition
 
     Scenarios:
       | state     | copy                                                                                                  |
-      | closed    | Find out about the Citizen Participation and Public Petitions Committee’s discussion of this petition |
+      | closed    | Find out about the Public Petitions Committee’s discussion of this petition |
       | completed | Find out about the decisions taken on this petition                                                   |
 
   Scenario: Suzie sees a message when viewing a petition and signature collection has been paused

--- a/package-lock.json
+++ b/package-lock.json
@@ -836,7 +836,8 @@
       "resolved": "https://registry.npmjs.org/jasmine-core/-/jasmine-core-6.3.0.tgz",
       "integrity": "sha512-eMm5qBovNjNoGOcgE/W207+wrcK5zrQv0Rg/rWGboUJUmZp0dFCpHTyjpuDAfCwRCqg7f9U2q2jtv/aUuzdCQg==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/jszip": {
       "version": "3.10.1",

--- a/spec/fixtures/notify/031cf660-43e3-4d8b-91ea-1e7ce2ddc140.yml
+++ b/spec/fixtures/notify/031cf660-43e3-4d8b-91ea-1e7ce2ddc140.yml
@@ -17,7 +17,7 @@ body: |-
   The petition: ((petition_url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you created this petition: “((action_gd))”.

--- a/spec/fixtures/notify/0ad7a912-1444-49c9-b915-f4969f24376f.yml
+++ b/spec/fixtures/notify/0ad7a912-1444-49c9-b915-f4969f24376f.yml
@@ -9,10 +9,10 @@ body: |-
   Click this link to see the petition and start sharing it:
   ((url_gd))
 
-  Information gathered and reported by the Citizen Participation and Public Petitions Committee regarding the petition will be updated on the Scottish Parliament Website here: ((petition_website_url_gd))
+  Information gathered and reported by the Public Petitions Committee regarding the petition will be updated on the Scottish Parliament Website here: ((petition_website_url_gd))
 
   Finally, should you require any further information in the meantime, please do not hesitate to contact us.
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/0e0cbb33-2546-45b8-8445-cd7281cd2f44.yml
+++ b/spec/fixtures/notify/0e0cbb33-2546-45b8-8445-cd7281cd2f44.yml
@@ -13,7 +13,7 @@ body: |-
   Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less, however we have a very large number to check at the moment so it is likely to take longer. Thank you for your patience.
   
   Thanks, 
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   ---

--- a/spec/fixtures/notify/111a4136-365b-48ee-bf2f-be60e5798bdc.yml
+++ b/spec/fixtures/notify/111a4136-365b-48ee-bf2f-be60e5798bdc.yml
@@ -21,5 +21,5 @@ body: |-
   We’re sorry that we’re not able to take your petition forward on this occasion.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/112c46d3-980e-4d56-83e8-06bb98a57871.yml
+++ b/spec/fixtures/notify/112c46d3-980e-4d56-83e8-06bb98a57871.yml
@@ -12,5 +12,5 @@ body: |-
   ((url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/13846021-76c3-41d1-8f6d-a452fc763c67.yml
+++ b/spec/fixtures/notify/13846021-76c3-41d1-8f6d-a452fc763c67.yml
@@ -24,5 +24,5 @@ body: |-
   We’re sorry that we’re not able to take your petition forward on this occasion.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/13feeec9-d539-4548-a1cf-13254a51af1c.yml
+++ b/spec/fixtures/notify/13feeec9-d539-4548-a1cf-13254a51af1c.yml
@@ -14,5 +14,5 @@ body: |-
   ((url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/17729e9f-859c-43f4-a0c1-2d82823d54b8.yml
+++ b/spec/fixtures/notify/17729e9f-859c-43f4-a0c1-2d82823d54b8.yml
@@ -13,7 +13,7 @@ body: |-
   Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition criteria. If it does we’ll publish it and let you know. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
   
   Thanks, 
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   ---

--- a/spec/fixtures/notify/180c8aed-726a-46cf-aef6-2a0a34906cb4.yml
+++ b/spec/fixtures/notify/180c8aed-726a-46cf-aef6-2a0a34906cb4.yml
@@ -10,7 +10,7 @@ body: |-
   ((body_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you signed this petition: “((action_en))”.

--- a/spec/fixtures/notify/1915c783-3b72-4a77-91b2-abb67e44bd07.yml
+++ b/spec/fixtures/notify/1915c783-3b72-4a77-91b2-abb67e44bd07.yml
@@ -13,7 +13,7 @@ body: |-
   Once the debate has happened, we’ll email you a video and transcript.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you created this petition: “((action_gd))”.

--- a/spec/fixtures/notify/1b64c2cc-d9f0-49ef-920e-34716aff1fc2.yml
+++ b/spec/fixtures/notify/1b64c2cc-d9f0-49ef-920e-34716aff1fc2.yml
@@ -10,7 +10,7 @@ body: |-
   ((body_en))
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
 
   You’re receiving this email because you created this petition: “((action_en))”.

--- a/spec/fixtures/notify/20cb31ed-5758-4fd4-9d0d-69fe6c1f4818.yml
+++ b/spec/fixtures/notify/20cb31ed-5758-4fd4-9d0d-69fe6c1f4818.yml
@@ -14,5 +14,5 @@ body: |-
   ((url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/2386c97c-307f-4d40-ad48-9e44e2eaecd7.yml
+++ b/spec/fixtures/notify/2386c97c-307f-4d40-ad48-9e44e2eaecd7.yml
@@ -19,5 +19,5 @@ body: |-
   ((standards_url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/2b58dfc1-4d92-4e98-82b8-2674036071df.yml
+++ b/spec/fixtures/notify/2b58dfc1-4d92-4e98-82b8-2674036071df.yml
@@ -13,7 +13,7 @@ body: |-
   Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less.
   
   Thanks, 
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   ---

--- a/spec/fixtures/notify/2b9f7f53-1f28-446d-9502-cb77d0928f61.yml
+++ b/spec/fixtures/notify/2b9f7f53-1f28-446d-9502-cb77d0928f61.yml
@@ -9,12 +9,12 @@ body: |-
   # ((action_en))
   ((url_en))
 
-  After you have confirmed your email, The Citizen Participation and Public Petitions team will review your petition and contact you to discuss the next steps.
+  After you have confirmed your email, The Public Petitions team will review your petition and contact you to discuss the next steps.
 
   Find out how we check petitions before we publish them
   ((moderation_info_url_en))
 
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/350b544c-47ef-4559-8d73-c374ec7db8d7.yml
+++ b/spec/fixtures/notify/350b544c-47ef-4559-8d73-c374ec7db8d7.yml
@@ -16,5 +16,5 @@ body: |-
   ((standards_url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/374a45ab-b871-423f-a0cb-6a3bd090dc19.yml
+++ b/spec/fixtures/notify/374a45ab-b871-423f-a0cb-6a3bd090dc19.yml
@@ -13,7 +13,7 @@ body: |-
   Find out more about the Petitions Committee: ((petitions_committee_url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you created this petition: “((action_gd))”.

--- a/spec/fixtures/notify/3949e09a-19fe-46de-b7cc-cd25c6e1360e.yml
+++ b/spec/fixtures/notify/3949e09a-19fe-46de-b7cc-cd25c6e1360e.yml
@@ -14,5 +14,5 @@ body: |-
   ((url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/3a7e8201-52c5-4dc9-a349-7e2235312147.yml
+++ b/spec/fixtures/notify/3a7e8201-52c5-4dc9-a349-7e2235312147.yml
@@ -5,5 +5,5 @@ body: |-
   You’re receiving this email because your email has been used to support the petition “((action))”, but you have already supported this petition.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/3e998aef-a6cf-45f2-b3af-80ddf2375ddd.yml
+++ b/spec/fixtures/notify/3e998aef-a6cf-45f2-b3af-80ddf2375ddd.yml
@@ -13,7 +13,7 @@ body: |-
   Once the debate has happened, we’ll email you a video and transcript.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you signed this petition: “((action_en))”.

--- a/spec/fixtures/notify/3ed42402-0038-4304-b910-08eaa4ec580b.yml
+++ b/spec/fixtures/notify/3ed42402-0038-4304-b910-08eaa4ec580b.yml
@@ -13,7 +13,7 @@ body: |-
   Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less.
   
   Thanks, 
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   ---

--- a/spec/fixtures/notify/3f08c4ae-f37b-4bc0-a96e-5495d4048411.yml
+++ b/spec/fixtures/notify/3f08c4ae-f37b-4bc0-a96e-5495d4048411.yml
@@ -13,7 +13,7 @@ body: |-
   Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
   
   Thanks, 
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   ---

--- a/spec/fixtures/notify/43eec5b3-3630-45bb-8a0f-38dbad99d3e6.yml
+++ b/spec/fixtures/notify/43eec5b3-3630-45bb-8a0f-38dbad99d3e6.yml
@@ -13,5 +13,5 @@ body: |-
   
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/4ef93900-6278-433e-9a11-36700c57da29.yml
+++ b/spec/fixtures/notify/4ef93900-6278-433e-9a11-36700c57da29.yml
@@ -13,7 +13,7 @@ body: |-
   Find out more about the Petitions Committee: ((petitions_committee_url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you signed this petition: “((action_gd))”.

--- a/spec/fixtures/notify/506fd5ab-379f-4a0d-9913-b151abad69a9.yml
+++ b/spec/fixtures/notify/506fd5ab-379f-4a0d-9913-b151abad69a9.yml
@@ -24,5 +24,5 @@ body: |-
   We’re sorry that we’re not able to take your petition forward on this occasion.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/58995764-cee9-49c5-a381-ce4871bda223.yml
+++ b/spec/fixtures/notify/58995764-cee9-49c5-a381-ce4871bda223.yml
@@ -4,15 +4,15 @@ subject: "We published your petition “((action_gd))”"
 body: |-
   Dear ((creator)),
 
-  Your petition “((action_gd))” is now published and will be scheduled for consideration by the Citizen Participation and Public Petitions Committee. We aim to inform petitioners 2 weeks in advance as to when their petition will be on the agenda.
+  Your petition “((action_gd))” is now published and will be scheduled for consideration by the Public Petitions Committee. We aim to inform petitioners 2 weeks in advance as to when their petition will be on the agenda.
 
   Click this link to see your petition and start sharing it:
   ((url_gd))
 
-  Information gathered and reported by the Citizen Participation and Public Petitions Committee regarding your petition will be updated on the Scottish Parliament Website here: ((petition_website_url_gd))
+  Information gathered and reported by the Public Petitions Committee regarding your petition will be updated on the Scottish Parliament Website here: ((petition_website_url_gd))
 
   Finally, should you require any further information in the meantime, please do not hesitate to contact us.
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/59a256a3-e0e8-4bc7-923a-142a42410ea9.yml
+++ b/spec/fixtures/notify/59a256a3-e0e8-4bc7-923a-142a42410ea9.yml
@@ -16,5 +16,5 @@ body: |-
   ((standards_url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/5cca1ad8-1214-41b0-8abe-bf982463dc01.yml
+++ b/spec/fixtures/notify/5cca1ad8-1214-41b0-8abe-bf982463dc01.yml
@@ -5,5 +5,5 @@ body: |-
   You’re receiving this email because your email has been used to support the petition “((action))”, but you have already supported this petition.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/61647c95-10f3-445b-aa38-1cbe436663b6.yml
+++ b/spec/fixtures/notify/61647c95-10f3-445b-aa38-1cbe436663b6.yml
@@ -10,7 +10,7 @@ body: |-
   ((body_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you signed this petition: “((action_gd))”.

--- a/spec/fixtures/notify/61bf3c20-decd-4aa6-88e0-9df929b4dae8.yml
+++ b/spec/fixtures/notify/61bf3c20-decd-4aa6-88e0-9df929b4dae8.yml
@@ -22,5 +22,5 @@ body: |-
   We’re sorry that we’re not able to take your petition forward on this occasion.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/6297d459-b8be-4872-82e5-1cb1e52921c5.yml
+++ b/spec/fixtures/notify/6297d459-b8be-4872-82e5-1cb1e52921c5.yml
@@ -22,5 +22,5 @@ body: |-
   We’re sorry that we’re not able to take your petition forward on this occasion.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/6b082ec8-af7d-4333-98a9-9ca71bfc9950.yml
+++ b/spec/fixtures/notify/6b082ec8-af7d-4333-98a9-9ca71bfc9950.yml
@@ -13,7 +13,7 @@ body: |-
   Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition criteria. If it does we’ll publish it and let you know. This usually takes a week or less but over the Christmas period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
   
   Thanks, 
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   ---

--- a/spec/fixtures/notify/6cd02568-0627-4932-a81d-23bf543840da.yml
+++ b/spec/fixtures/notify/6cd02568-0627-4932-a81d-23bf543840da.yml
@@ -17,5 +17,5 @@ body: |-
   ((standards_url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/71f415b2-6488-4dc5-aa47-91ebaad41faf.yml
+++ b/spec/fixtures/notify/71f415b2-6488-4dc5-aa47-91ebaad41faf.yml
@@ -12,5 +12,5 @@ body: |-
   ((url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/73de5200-a8a7-47f1-a6c7-b2a90c2ba419.yml
+++ b/spec/fixtures/notify/73de5200-a8a7-47f1-a6c7-b2a90c2ba419.yml
@@ -13,7 +13,7 @@ body: |-
   Once the debate has happened, we’ll email you a video and transcript.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you signed this petition: “((action_gd))”.

--- a/spec/fixtures/notify/87e8900d-5f1a-4366-9d40-c424173c4806.yml
+++ b/spec/fixtures/notify/87e8900d-5f1a-4366-9d40-c424173c4806.yml
@@ -17,5 +17,5 @@ body: |-
   ((standards_url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/8c18ec4e-c6a5-4939-bbdd-19fbb1e392d3.yml
+++ b/spec/fixtures/notify/8c18ec4e-c6a5-4939-bbdd-19fbb1e392d3.yml
@@ -14,5 +14,5 @@ body: |-
   ((url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/918ff0be-d33e-4ad5-ad9c-da2f339e8070.yml
+++ b/spec/fixtures/notify/918ff0be-d33e-4ad5-ad9c-da2f339e8070.yml
@@ -13,7 +13,7 @@ body: |-
   Find out more about the Petitions Committee: ((petitions_committee_url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you signed this petition: “((action_en))”.

--- a/spec/fixtures/notify/925889ef-245f-4f41-adbc-2378d079d1c6.yml
+++ b/spec/fixtures/notify/925889ef-245f-4f41-adbc-2378d079d1c6.yml
@@ -21,5 +21,5 @@ body: |-
   We’re sorry that we’re not able to take your petition forward on this occasion.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/a18a2bbf-df46-4f7f-8202-dcfe2c9ba188.yml
+++ b/spec/fixtures/notify/a18a2bbf-df46-4f7f-8202-dcfe2c9ba188.yml
@@ -9,10 +9,10 @@ body: |-
   Click this link to see your petition and start sharing it:
   ((url_gd))
 
-  Information gathered and reported by the Citizen Participation and Public Petitions Committee regarding your petition will be updated on the Scottish Parliament Website here: ((petition_website_url_gd))
+  Information gathered and reported by the Public Petitions Committee regarding your petition will be updated on the Scottish Parliament Website here: ((petition_website_url_gd))
 
   Finally, should you require any further information in the meantime, please do not hesitate to contact us.
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/a3997c4b-8f4e-4013-abcb-fdbbbb6f5950.yml
+++ b/spec/fixtures/notify/a3997c4b-8f4e-4013-abcb-fdbbbb6f5950.yml
@@ -8,5 +8,5 @@ body: |-
   ((url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/a41374bb-235b-4203-8ed2-076961c7554c.yml
+++ b/spec/fixtures/notify/a41374bb-235b-4203-8ed2-076961c7554c.yml
@@ -14,5 +14,5 @@ body: |-
   ((url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/a86c7fc5-dc56-4cbc-93cb-7ed289f76938.yml
+++ b/spec/fixtures/notify/a86c7fc5-dc56-4cbc-93cb-7ed289f76938.yml
@@ -13,7 +13,7 @@ body: |-
   Find out more about the Petitions Committee: ((petitions_committee_url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you created this petition: “((action_en))”.

--- a/spec/fixtures/notify/b79b908a-5b2f-4577-a03e-d8c625a2e280.yml
+++ b/spec/fixtures/notify/b79b908a-5b2f-4577-a03e-d8c625a2e280.yml
@@ -9,5 +9,5 @@ body: |-
   ((url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/ba9c3050-cc8b-410b-b3d2-30c692ffb91c.yml
+++ b/spec/fixtures/notify/ba9c3050-cc8b-410b-b3d2-30c692ffb91c.yml
@@ -8,5 +8,5 @@ body: |-
   ((url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/be4a7709-d813-4257-ab45-fda327aef2d9.yml
+++ b/spec/fixtures/notify/be4a7709-d813-4257-ab45-fda327aef2d9.yml
@@ -17,7 +17,7 @@ body: |-
   The petition: ((petition_url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you created this petition: “((action_en))”.

--- a/spec/fixtures/notify/c277d917-d95a-4724-952c-e55f3577a6ad.yml
+++ b/spec/fixtures/notify/c277d917-d95a-4724-952c-e55f3577a6ad.yml
@@ -13,7 +13,7 @@ body: |-
   Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition standards. If it does we’ll publish it. This usually takes a week or less but over the Easter period it will take us a little longer than usual. We’ll check your petition as quickly as we can.
   
   Thanks, 
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   ---

--- a/spec/fixtures/notify/cb8144c1-3d7c-417b-9add-261fe4253d24.yml
+++ b/spec/fixtures/notify/cb8144c1-3d7c-417b-9add-261fe4253d24.yml
@@ -14,5 +14,5 @@ body: |-
   ((url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/cbf205c3-9d3a-4d97-8dd6-c367ecaeb8cd.yml
+++ b/spec/fixtures/notify/cbf205c3-9d3a-4d97-8dd6-c367ecaeb8cd.yml
@@ -9,12 +9,12 @@ body: |-
   # ((action_en))
   ((url_en))
 
-  After you have confirmed your email, The Citizen Participation and Public Petitions team will review your petition and contact you to discuss the next steps.
+  After you have confirmed your email, The Public Petitions team will review your petition and contact you to discuss the next steps.
 
   Find out how we check petitions before we publish them
   ((moderation_info_url_en))
 
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/cca515de-ba0a-492f-b23a-1bafd8a803b8.yml
+++ b/spec/fixtures/notify/cca515de-ba0a-492f-b23a-1bafd8a803b8.yml
@@ -4,15 +4,15 @@ subject: "We published the petition “((action_en))” that you supported"
 body: |-
   Dear ((sponsor)),
 
-  The petition “((action_en))” is now published and will be scheduled for consideration by the Citizen Participation and Public Petitions Committee.
+  The petition “((action_en))” is now published and will be scheduled for consideration by the Public Petitions Committee.
 
   Click this link to see the petition and start sharing it:
   ((url_en))
 
-  Information gathered and reported by the Citizen Participation and Public Petitions Committee regarding the petition will be updated on the Scottish Parliament Website here: ((petition_website_url_en))
+  Information gathered and reported by the Public Petitions Committee regarding the petition will be updated on the Scottish Parliament Website here: ((petition_website_url_en))
 
   Finally, should you require any further information in the meantime, please do not hesitate to contact us.
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/d1f5e610-5455-41ec-b71d-776c61ad9cac.yml
+++ b/spec/fixtures/notify/d1f5e610-5455-41ec-b71d-776c61ad9cac.yml
@@ -9,5 +9,5 @@ body: |-
   ((url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/d2777d25-c434-4196-8ed5-54460b71f7c9.yml
+++ b/spec/fixtures/notify/d2777d25-c434-4196-8ed5-54460b71f7c9.yml
@@ -17,7 +17,7 @@ body: |-
   The petition: ((petition_url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you signed this petition: “((action_en))”.

--- a/spec/fixtures/notify/d807f6ff-700d-4785-a41e-4572d3dd9dfa.yml
+++ b/spec/fixtures/notify/d807f6ff-700d-4785-a41e-4572d3dd9dfa.yml
@@ -13,5 +13,5 @@ body: |-
   
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/d9d30b35-9e57-421c-9421-b5c234f314ed.yml
+++ b/spec/fixtures/notify/d9d30b35-9e57-421c-9421-b5c234f314ed.yml
@@ -13,7 +13,7 @@ body: |-
   Once you’ve gained the required number of supporters, we’ll check your petition to make sure it meets the petition criteria. If it does, we’ll publish it and let you know. This usually takes a week or less, however we have a very large number to check at the moment so it is likely to take longer. Thank you for your patience.
   
   Thanks, 
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   ---

--- a/spec/fixtures/notify/e62c1f63-ea30-4d91-86a2-4e290c13fb0c.yml
+++ b/spec/fixtures/notify/e62c1f63-ea30-4d91-86a2-4e290c13fb0c.yml
@@ -10,7 +10,7 @@ body: |-
   ((body_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you created this petition: “((action_gd))”.

--- a/spec/fixtures/notify/ee19da6b-d626-4a52-9e96-8ec631db250c.yml
+++ b/spec/fixtures/notify/ee19da6b-d626-4a52-9e96-8ec631db250c.yml
@@ -4,15 +4,15 @@ subject: "We published the petition “((action_gd))” that you supported"
 body: |-
   Dear ((sponsor)),
 
-  The petition “((action_gd))” is now published and will be scheduled for consideration by the Citizen Participation and Public Petitions Committee.
+  The petition “((action_gd))” is now published and will be scheduled for consideration by the Public Petitions Committee.
 
   Click this link to see the petition and start sharing it:
    ((url_gd))
 
-  Information gathered and reported by the Citizen Participation and Public Petitions Committee regarding the petition will be updated on the Scottish Parliament Website here: ((petition_website_url_gd))
+  Information gathered and reported by the Public Petitions Committee regarding the petition will be updated on the Scottish Parliament Website here: ((petition_website_url_gd))
 
   Finally, should you require any further information in the meantime, please do not hesitate to contact us.
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/eedd584c-1ea0-40cb-81d5-df30b9dc4a59.yml
+++ b/spec/fixtures/notify/eedd584c-1ea0-40cb-81d5-df30b9dc4a59.yml
@@ -13,7 +13,7 @@ body: |-
   Once the debate has happened, we’ll email you a video and transcript.
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you created this petition: “((action_en))”.

--- a/spec/fixtures/notify/f13efab8-fa6d-4504-8be3-75eac3c8dd14.yml
+++ b/spec/fixtures/notify/f13efab8-fa6d-4504-8be3-75eac3c8dd14.yml
@@ -4,14 +4,14 @@ subject: "We published your petition “((action_en))”"
 body: |-
   Dear ((creator)),
 
-  Your petition “((action_en))” is now published and will be scheduled for consideration by the Citizen Participation and Public Petitions Committee. We aim to inform petitioners 2 weeks in advance as to when their petition will be on the agenda.
+  Your petition “((action_en))” is now published and will be scheduled for consideration by the Public Petitions Committee. We aim to inform petitioners 2 weeks in advance as to when their petition will be on the agenda.
 
   Click this link to see your petition and start sharing it: ((url_en))
 
-  Information gathered and reported by the Citizen Participation and Public Petitions Committee regarding your petition will be updated on the Scottish Parliament Website here: ((petition_website_url_en))
+  Information gathered and reported by the Public Petitions Committee regarding your petition will be updated on the Scottish Parliament Website here: ((petition_website_url_en))
 
   Finally, should you require any further information in the meantime, please do not hesitate to contact us.
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/f23547af-65d8-4d9d-82cb-6f247112217e.yml
+++ b/spec/fixtures/notify/f23547af-65d8-4d9d-82cb-6f247112217e.yml
@@ -9,10 +9,10 @@ body: |-
   Click this link to see your petition and start sharing it:
   ((url_en))
 
-  Information gathered and reported by the Citizen Participation and Public Petitions Committee regarding your petition will be updated on the Scottish Parliament Website here: ((petition_website_url_en))
+  Information gathered and reported by the Public Petitions Committee regarding your petition will be updated on the Scottish Parliament Website here: ((petition_website_url_en))
 
   Finally, should you require any further information in the meantime, please do not hesitate to contact us.
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/f622a170-c0cf-42ca-aef6-66deb7f25611.yml
+++ b/spec/fixtures/notify/f622a170-c0cf-42ca-aef6-66deb7f25611.yml
@@ -9,10 +9,10 @@ body: |-
   Click this link to see the petition and start sharing it:
   ((url_en))
 
-  Information gathered and reported by the Citizen Participation and Public Petitions Committee regarding the petition will be updated on the Scottish Parliament Website here: ((petition_website_url_en))
+  Information gathered and reported by the Public Petitions Committee regarding the petition will be updated on the Scottish Parliament Website here: ((petition_website_url_en))
 
   Finally, should you require any further information in the meantime, please do not hesitate to contact us.
 
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/f9e6a3f3-7eb0-4ab9-baa2-0f517d1e51c8.yml
+++ b/spec/fixtures/notify/f9e6a3f3-7eb0-4ab9-baa2-0f517d1e51c8.yml
@@ -19,5 +19,5 @@ body: |-
   ((standards_url_en))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament

--- a/spec/fixtures/notify/fc58c0b6-217b-4d3b-9a9f-2537bb16f636.yml
+++ b/spec/fixtures/notify/fc58c0b6-217b-4d3b-9a9f-2537bb16f636.yml
@@ -17,7 +17,7 @@ body: |-
   The petition: ((petition_url_gd))
   
   Thanks,
-  The Citizen Participation and Public Petitions team
+  The Public Petitions team
   The Scottish Parliament
   
   You’re receiving this email because you signed this petition: “((action_gd))”.

--- a/spec/helpers/home_helper_spec.rb
+++ b/spec/helpers/home_helper_spec.rb
@@ -47,19 +47,19 @@ RSpec.describe HomeHelper, type: :helper do
 
       context "when the petition count is 1" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:referred, 1)).to eq("<span class=\"count\">1</span> petition was referred to the Citizen Participation and Public Petitions Committee")
+          expect(helper.petition_count(:referred, 1)).to eq("<span class=\"count\">1</span> petition was referred to the Public Petitions Committee")
         end
       end
 
       context "when the petition count is 100" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:referred, 100)).to eq("<span class=\"count\">100</span> petitions were referred to the Citizen Participation and Public Petitions Committee")
+          expect(helper.petition_count(:referred, 100)).to eq("<span class=\"count\">100</span> petitions were referred to the Public Petitions Committee")
         end
       end
 
       context "when the petition count is 1000" do
         it "returns a correctly formatted petition count" do
-          expect(helper.petition_count(:referred, 1000)).to eq("<span class=\"count\">1,000</span> petitions were referred to the Citizen Participation and Public Petitions Committee")
+          expect(helper.petition_count(:referred, 1000)).to eq("<span class=\"count\">1,000</span> petitions were referred to the Public Petitions Committee")
         end
       end
     end

--- a/spec/lib/notifications/markdown_spec.rb
+++ b/spec/lib/notifications/markdown_spec.rb
@@ -89,7 +89,7 @@ RSpec.describe Notifications::Markdown do
     it "hard wraps paragraphs" do
       markdown_to_html <<~MD
         Thanks,
-        The Citizen Participation and Public Petitions team
+        The Public Petitions team
         The Scottish Parliament
       MD
 
@@ -315,7 +315,7 @@ RSpec.describe Notifications::Markdown do
           * It's not the remit of the Scottish Parliament/Government
 
           Thanks,
-          The Citizen Participation and Public Petitions team
+          The Public Petitions team
           The Scottish Parliament
         MD
       )).to eq <<~TEXT
@@ -344,7 +344,7 @@ RSpec.describe Notifications::Markdown do
         * It's not the remit of the Scottish Parliament/Government
 
         Thanks,
-        The Citizen Participation and Public Petitions team
+        The Public Petitions team
         The Scottish Parliament
 
       TEXT
@@ -381,7 +381,7 @@ RSpec.describe Notifications::Markdown do
           * It's not the remit of the Scottish Parliament/Government
 
           Thanks,
-          The Citizen Participation and Public Petitions team
+          The Public Petitions team
           The Scottish Parliament
         MD
       )).to eq <<~TEXT.squish

--- a/spec/lib/notifications/template_spec.rb
+++ b/spec/lib/notifications/template_spec.rb
@@ -67,7 +67,7 @@ RSpec.describe Notifications::Template, type: :model do
           ((url_en))
 
           Thanks,
-          The Citizen Participation and Public Petitions team
+          The Public Petitions team
           The Scottish Parliament
         MD
       )
@@ -230,7 +230,7 @@ RSpec.describe Notifications::Template, type: :model do
           ((url_en))
 
           Thanks,
-          The Citizen Participation and Public Petitions team
+          The Public Petitions team
           The Scottish Parliament
         MD
       )
@@ -272,7 +272,7 @@ RSpec.describe Notifications::Template, type: :model do
                 assert_select "p:first-child", "Click this link to sign the petition:"
                 assert_select "h2", "{{action_en}}"
                 assert_select "p > a[href='{{url_en}}']", "{{url_en}}"
-                assert_select "p:last-child", "Thanks, The Citizen Participation and Public Petitions team The Scottish Parliament"
+                assert_select "p:last-child", "Thanks, The Public Petitions team The Scottish Parliament"
                 assert_select "p:last-child br", count: 2
               end
             end
@@ -293,7 +293,7 @@ RSpec.describe Notifications::Template, type: :model do
           {{url_en}}
 
           Thanks,
-          The Citizen Participation and Public Petitions team
+          The Public Petitions team
           The Scottish Parliament
 
 


### PR DESCRIPTION
The committee name is now 'Public Petitions Committee' though there's still a couple of places we reference the old name as that was the name at determination of the new rules.