### PR TITLE
Fix intermittent ci failures

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
     logstash-event (1.2.02)
     logstash-logger (0.26.1)
       logstash-event (~> 1.2)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -343,8 +343,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     railties (8.0.5)
       actionpack (= 8.0.5)
@@ -621,7 +621,7 @@ CHECKSUMS
   lograge (0.15.0) sha256=34072c1f50b95019dc185137f5fec1a6759f5a1b6d55c28163d0cba204e6df16
   logstash-event (1.2.02) sha256=89a7dc60fac67070a5f60ba07409e541b09cb58906c391e90cb74b9f217467ae
   logstash-logger (0.26.1) sha256=577ab470cb177630e4603804e7cfe264c0690c520ed0b4705786d04cfe9300da
-  loofah (2.25.1) sha256=d436c73dbd0c1147b16c4a41db097942d217303e1f7728704b37e4df9f6d2e04
+  loofah (2.25.2) sha256=2007f746959ac65552456e04b433e83deb22759ab38c838b4445c70e43425918
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.2.1) sha256=1678e9360e32f9eafa917c80029e2f6d10b2715c66a4b87b6d0da9b9cd1f859f
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
@@ -661,7 +661,7 @@ CHECKSUMS
   rails (8.0.5) sha256=4cb40f90948be292fa15cc7cb37757b97266585145c6e76957464b40edfd5be6
   rails-controller-testing (1.0.5) sha256=741448db59366073e86fc965ba403f881c636b79a2c39a48d0486f2607182e94
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
-  rails-html-sanitizer (1.7.0) sha256=28b145cceaf9cc214a9874feaa183c3acba036c9592b19886e0e45efc62b1e89
+  rails-html-sanitizer (1.7.1) sha256=e797a7c9b01e567307e317c576b49ab4168017e63eea4dba9ce3cb587e2f22c2
   railties (8.0.5) sha256=ad98c6e9a096b7e8cf63c70872b60ec6c1d4152be2a4ffa63483ec02a837a9d5
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   rb-fsevent (0.11.2) sha256=43900b972e7301d6570f64b850a5aa67833ee7d87b458ee92805d56b7318aefe

--- a/app/models/site.rb
+++ b/app/models/site.rb
@@ -32,6 +32,7 @@ class Site < ActiveRecord::Base
     disable_other_business
     disable_thresholds_and_debates
     disable_petition_creation
+    disable_petition_moderation_locking
     disable_collecting_signatures
   ]
 
@@ -241,6 +242,14 @@ class Site < ActiveRecord::Base
 
     def moderation_near_overdue_in_days
       5.days
+    end
+
+    def disable_petition_moderation_locking!
+      instance.update!(disable_petition_moderation_locking: true)
+    end
+
+    def enable_petition_moderation_locking!
+      instance.update!(disable_petition_moderation_locking: false)
     end
 
     def defaults

--- a/app/views/admin/admin/_edit_lock.html.erb
+++ b/app/views/admin/admin/_edit_lock.html.erb
@@ -1,17 +1,19 @@
-<div id="edit-lock">
-  <div class="edit-lock-modal">
-    <p class="edit-lock-message">
-      This petition is currently being edited by someone else.
-    </p>
-    <p class="edit-lock-actions">
-      <button id="edit-lock-override" class="button">Override</button>
-      <button id="edit-lock-cancel" class="button-secondary">Cancel</button>
-    </p>
+<% unless Site.disable_petition_moderation_locking? %>
+  <div id="edit-lock">
+    <div class="edit-lock-modal">
+      <p class="edit-lock-message">
+        This petition is currently being edited by someone else.
+      </p>
+      <p class="edit-lock-actions">
+        <button id="edit-lock-override" class="button">Override</button>
+        <button id="edit-lock-cancel" class="button-secondary">Cancel</button>
+      </p>
+    </div>
   </div>
-</div>
 
-<script>
-  $(document).ready(function() {
-    $("#edit-lock").editLock(<%= @petition.id %>, <%= current_user.id %>, '/admin/petitions', <%= @petition.moderated? %>);
-  });
-</script>
+  <script>
+    $(document).ready(function() {
+      $("#edit-lock").editLock(<%= @petition.id %>, <%= current_user.id %>, '/admin/petitions', <%= @petition.moderated? %>);
+    });
+  </script>
+<% end %>

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -64,6 +64,14 @@ After do
   Site.reload
 end
 
+Before('@locking') do
+  Site.enable_petition_moderation_locking!
+end
+
+Before('not @locking') do
+  Site.disable_petition_moderation_locking!
+end
+
 Before('@gaelic') do
   I18n.locale = :"gd-GB"
 end

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -4,6 +4,30 @@ Before('@javascript') do
   end
 end
 
+Before do |s|
+  message = <<~TEXT
+    ================================================================================
+    =                                                                              =
+    = BEGIN: #{sprintf("%-69s", s.name)} =
+    =                                                                              =
+    ================================================================================
+  TEXT
+
+  Rails.logger.debug(message)
+end
+
+After do |s|
+  message = <<~TEXT
+    ================================================================================
+    =                                                                              =
+    = AFTER: #{sprintf("%-69s", s.name)} =
+    =                                                                              =
+    ================================================================================
+  TEXT
+
+  Rails.logger.debug(message)
+end
+
 Before do
   default_url_options[:protocol] = 'https'
 end


### PR DESCRIPTION
The edit lock feature uses the javascript sendBeacon feature to send an unlock request after a window closes. This often happens while the database is being truncated by Database Cleaner and can cause deadlocks in the database.

To work around this we can disable the feature for the cucumber specs as it's not needed since we're not testing concurrent edit access.
